### PR TITLE
get group details - resource metrics and costs

### DIFF
--- a/pkg/plugin/commons.go
+++ b/pkg/plugin/commons.go
@@ -19,10 +19,15 @@ package plugin
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // nolint
@@ -36,4 +41,44 @@ func executeCommand(command string) []byte {
 		log.Fatal(err)
 	}
 	return out.Bytes()
+}
+
+// getCurrentTime returns the current time as k8s apimachinery Time object
+func getCurrentTime() meta_v1.Time {
+	return meta_v1.Now()
+}
+
+// getCurrentMonthStartTime returns month start time as k8s apimachinery Time object
+func getCurrentMonthStartTime() meta_v1.Time {
+	now := time.Now()
+	monthStart := meta_v1.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local)
+	return monthStart
+}
+
+/*
+currentMonthActiveTimeInHours returns active time (endTime - startTime) in the current month.
+1. If startTime is before month start then it is set as month start
+2. If endTime is not set(isZero) then it is set as current time
+These two conditions ensures that the active time we compute is within the current month.
+*/
+func currentMonthActiveTimeInHours(startTime, endTime, currentTime, monthStart meta_v1.Time) float64 {
+	if startTime.Time.Before(monthStart.Time) {
+		startTime = monthStart
+	}
+
+	if endTime.IsZero() {
+		endTime = currentTime
+	}
+
+	duration := endTime.Time.Sub(startTime.Time)
+	durationInHours := duration.Hours()
+	return durationInHours
+}
+
+func resourceQuantityToFloat64(quantity *resource.Quantity) float64 {
+	val, isSuccess := quantity.AsInt64()
+	if !isSuccess {
+		fmt.Println("Unable to convert resource quantity into int64")
+	}
+	return float64(val)
 }

--- a/pkg/plugin/crd/group_crd.go
+++ b/pkg/plugin/crd/group_crd.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/vmware/purser/pkg/plugin/metrics"
+
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -78,9 +79,25 @@ type Group struct {
 // GroupSpec definition
 type GroupSpec struct {
 	Name               string                      `json:"name"`
-	Type               string                      `json:"type"`
+	Type               string                      `json:"type,omitempty"`
+	Labels             map[string]string           `json:"labels,omitempty"`
 	AllocatedResources *metrics.Metrics            `json:"metrics,omitempty"`
 	PodsMetrics        map[string]*metrics.Metrics `json:"pods,omitempty"`
+	PodsDetails        map[string]*PodDetails      `json:"podDetails,omitempty"`
+}
+
+// PodDetails definition
+type PodDetails struct {
+	Name       string
+	StartTime  meta_v1.Time
+	EndTime    meta_v1.Time
+	Containers []*Container
+}
+
+// Container definition
+type Container struct {
+	Name    string
+	Metrics *metrics.Metrics
 }
 
 // GroupStatus details

--- a/pkg/plugin/metrics/metrics.go
+++ b/pkg/plugin/metrics/metrics.go
@@ -33,6 +33,16 @@ type Metrics struct {
 	MemoryRequest *resource.Quantity
 }
 
+// GroupMetrics Details
+// Here Active resource is the resource quantity active in the current month
+type GroupMetrics struct {
+	ActiveCPULimit       float64
+	ActiveMemoryLimit    float64
+	ActiveCPURequest     float64
+	ActiveMemoryRequest  float64
+	ActiveStorageClaimed float64
+}
+
 // CalculatePodStatsFromContainers returns pods stats from containers.
 func CalculatePodStatsFromContainers(pods []v1.Pod) *Metrics {
 	cpuLimit := &resource.Quantity{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Given a group, this **PR** calculates the aggregated metrics and costs over all the pods in the group.


**Special notes for your reviewer**:
Cost is based on per unit-resource per hour and the time of the resource used to calculate cost is its active time in the current month. This partly solves issue #4. And this is replacement for PR #8
