### PR TITLE
fix readme: show only current working commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ Currenty the below list of commands are supported for the Purser plugin.
 kubectl plugin purser get [summary|savings]
 
 # Query resources filtered by associated namespace, labels and groups.
-kubectl plugin purser get resources namespace <Namespace>
-kubectl plugin purser get resources label <key=val>
 kubectl plugin purser get resources group <group-name>
 
 # Query cost filtered by associated labels, pods and node.
 kubectl plugin purser get cost label <key=val>
 kubectl plugin purser get cost pod <pod name>
-kubectl plugin purser get cost node <node name>
+kubectl plugin purser get cost node all
 
 # Configure user-costs for the choice of deployment.
 kubectl plugin purser [set|get] user-costs

--- a/cmd/plugin/purser_plugin.go
+++ b/cmd/plugin/purser_plugin.go
@@ -181,12 +181,10 @@ func init() {
 func printHelp() {
 	fmt.Printf("Try one of the following commands...\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get summary\n")
-	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get resources namespace <Namespace>\n")
-	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get resources label <key=val>\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get resources group <group-name>\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get cost label <key=val>\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get cost pod <pod name>\n")
-	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get cost node <node name>\n")
+	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get cost node all\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser set user-costs\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get user-costs\n")
 	fmt.Printf("kubectl --kubeconfig=<absolute path to config> plugin purser get savings\n")

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -8,11 +8,9 @@ Use flag `--kubeconfig=<absolute path to config>` if your cluster configuration 
 ```
 kubectl plugin purser get summary
 kubectl plugin purser get savings
-kubectl plugin purser get resources namespace <Namespace>
-kubectl plugin purser get resources label <key=val>
 kubectl plugin purser get cost label <key=val>
 kubectl plugin purser get cost pod <pod name>
-kubectl plugin purser get cost node <node name>
+kubectl plugin purser get cost node all
 kubectl plugin purser set user-costs
 kubectl plugin purser get user-costs
 ```

--- a/pkg/plugin/pod.go
+++ b/pkg/plugin/pod.go
@@ -59,9 +59,11 @@ func getPodDetailsFromClient(podName string) *Pod {
 		panic(err.Error())
 	} else {
 		return &Pod{
-			name:     pod.GetObjectMeta().GetName(),
-			nodeName: pod.Spec.NodeName,
-			pvcs:     getPodVolumes(pod),
+			name:       pod.GetObjectMeta().GetName(),
+			nodeName:   pod.Spec.NodeName,
+			pvcs:       getPodVolumes(pod),
+			podMetrics: metrics.CalculatePodStatsFromContainers([]v1.Pod{*pod}),
+			startTime:  *pod.Status.StartTime,
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Readme fixes to show only current working commands. As we are not creating default groups for each namespace/label those commands were not working.