### PR TITLE
Handle deletion of resource in dgraph

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -185,6 +185,14 @@
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:ed615c5430ecabbb0fb7629a182da65ecee6523900ac1ac932520860878ffcad"
+  name = "github.com/robfig/cron"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b41be1df696709bb6395fe435af20370037c0b4c"
+  version = "v1.1"
+
+[[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -487,6 +495,7 @@
     "github.com/Sirupsen/logrus",
     "github.com/dgraph-io/dgo",
     "github.com/dgraph-io/dgo/protos/api",
+    "github.com/robfig/cron",
     "google.golang.org/grpc",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/batch/v1",

--- a/cmd/plugin/purser_plugin.go
+++ b/cmd/plugin/purser_plugin.go
@@ -20,9 +20,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/purser/pkg/client"
 	groups_client_v1 "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"

--- a/pkg/client/clientset.go
+++ b/pkg/client/clientset.go
@@ -19,8 +19,9 @@ package client
 
 import (
 	"flag"
-	"log"
 	"os/user"
+
+	log "github.com/Sirupsen/logrus"
 
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/rest"

--- a/pkg/client/clientset/typed/groups/v1/group_client.go
+++ b/pkg/client/clientset/typed/groups/v1/group_client.go
@@ -18,9 +18,10 @@
 package v1
 
 import (
-	"log"
 	"reflect"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
 

--- a/pkg/client/clientset/typed/subscriber/v1/subsciber_client.go
+++ b/pkg/client/clientset/typed/subscriber/v1/subsciber_client.go
@@ -18,9 +18,10 @@
 package v1
 
 import (
-	"log"
 	"reflect"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	subscriber_v1 "github.com/vmware/purser/pkg/apis/subscriber/v1"
 

--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -78,7 +78,6 @@ func StoreAndRetrieveContainers(pod api_v1.Pod, podUID string, isDeleted bool) [
 		if isDeleted {
 			container = &Container{
 				ID:      dgraph.ID{UID: containerUID, Xid: containerXid},
-				Pod:     Pod{ID: dgraph.ID{UID: podUID, Xid: podXid}},
 				EndTime: pod.GetDeletionTimestamp().Time,
 			}
 		} else {
@@ -95,6 +94,12 @@ func StoreAndRetrieveContainers(pod api_v1.Pod, podUID string, isDeleted bool) [
 		}
 
 		containers = append(containers, container)
+	}
+	if isDeleted {
+		err := deleteProcessesInTerminatedContainers(containers)
+		if err != nil {
+			log.Error(err)
+		}
 	}
 	return containers
 }

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -78,9 +78,8 @@ func StorePod(k8sPod api_v1.Pod) error {
 	isDeleted := !podDeletedTimestamp.IsZero()
 	if isDeleted {
 		pod = Pod{
-			ID:         dgraph.ID{Xid: xid, UID: uid},
-			Containers: StoreAndRetrieveContainers(k8sPod, uid, isDeleted),
-			EndTime:    podDeletedTimestamp.Time,
+			ID:      dgraph.ID{Xid: xid, UID: uid},
+			EndTime: podDeletedTimestamp.Time,
 		}
 	} else {
 		pod = Pod{

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -18,14 +18,13 @@
 package models
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/vmware/purser/pkg/controller/dgraph"
-	"github.com/vmware/purser/pkg/controller/utils"
 
 	api_v1 "k8s.io/api/core/v1"
 )
@@ -48,15 +47,14 @@ type Pod struct {
 }
 
 // newPod creates a new node for the pod in the Dgraph
-func newPod(k8sPod api_v1.Pod, xid string) (*api.Assigned, error) {
+func newPod(k8sPod api_v1.Pod) (*api.Assigned, error) {
 	pod := Pod{
 		Name:      k8sPod.Name,
 		IsPod:     true,
-		ID:        dgraph.ID{Xid: xid},
+		ID:        dgraph.ID{Xid: k8sPod.Namespace + ":" + k8sPod.Name},
 		StartTime: k8sPod.GetCreationTimestamp().Time,
 	}
-	bytes := utils.JSONMarshal(pod)
-	return dgraph.MutateNode(bytes)
+	return dgraph.MutateNode(pod, dgraph.CREATE)
 }
 
 // StorePod updates the pod details and create it a new node if not exists.
@@ -67,7 +65,7 @@ func StorePod(k8sPod api_v1.Pod) error {
 
 	var pod Pod
 	if uid == "" {
-		assigned, err := newPod(k8sPod, xid)
+		assigned, err := newPod(k8sPod)
 		if err != nil {
 			return err
 		}
@@ -75,24 +73,20 @@ func StorePod(k8sPod api_v1.Pod) error {
 	}
 
 	podDeletedTimestamp := k8sPod.GetDeletionTimestamp()
-	isDeleted := !podDeletedTimestamp.IsZero()
-	if isDeleted {
+	if !podDeletedTimestamp.IsZero() {
 		pod = Pod{
 			ID:      dgraph.ID{Xid: xid, UID: uid},
 			EndTime: podDeletedTimestamp.Time,
 		}
+		deleteContainersInTerminatedPod(pod.Containers, podDeletedTimestamp.Time)
 	} else {
 		pod = Pod{
 			ID:         dgraph.ID{Xid: xid, UID: uid},
-			Containers: StoreAndRetrieveContainers(k8sPod, uid, isDeleted),
+			Containers: StoreAndRetrieveContainers(k8sPod, uid),
 		}
 	}
 
-	bytes, err := json.Marshal(pod)
-	if err != nil {
-		return err
-	}
-	_, err = dgraph.MutateNode(bytes)
+	_, err := dgraph.MutateNode(pod, dgraph.UPDATE)
 	return err
 }
 
@@ -104,27 +98,12 @@ func StorePodsInteraction(sourcePodXID string, destinationPodsXIDs []string, cou
 		return fmt.Errorf("source pod: %s is not persisted yet", sourcePodXID)
 	}
 
-	pods := []*Pod{}
-	for index, destinationPodXID := range destinationPodsXIDs {
-		dstUID := dgraph.GetUID(destinationPodXID, IsPod)
-		if dstUID == "" {
-			log.Printf("Destination pod: %s is not persistet yet", destinationPodXID)
-			continue
-		}
-
-		pod := &Pod{
-			ID:    dgraph.ID{UID: dstUID, Xid: destinationPodXID},
-			Count: counts[index],
-		}
-		pods = append(pods, pod)
-	}
+	pods := retrievePodsWithCountAsEdgeWeightFromPodsXIDs(destinationPodsXIDs, counts)
 	source := Pod{
 		ID:        dgraph.ID{UID: uid, Xid: sourcePodXID},
 		Interacts: pods,
 	}
-
-	bytes := utils.JSONMarshal(source)
-	_, err := dgraph.MutateNode(bytes)
+	_, err := dgraph.MutateNode(source, dgraph.UPDATE)
 	return err
 }
 
@@ -148,4 +127,38 @@ func RetrieveAllPods() ([]Pod, error) {
 		return nil, err
 	}
 	return newRoot.Pods, nil
+}
+
+func retrievePodsFromPodsXIDs(podsXIDs []string) []*Pod {
+	pods := []*Pod{}
+	for _, podXID := range podsXIDs {
+		podUID := dgraph.GetUID(podXID, IsPod)
+		if podUID == "" {
+			log.Debugf("Pod uid is empty for pod xid: %s", podXID)
+			continue
+		}
+		pod := &Pod{
+			ID: dgraph.ID{UID: podUID, Xid: podXID},
+		}
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+func retrievePodsWithCountAsEdgeWeightFromPodsXIDs(podsXIDs []string, counts []float64) []*Pod {
+	pods := []*Pod{}
+	for index, podXID := range podsXIDs {
+		podUID := dgraph.GetUID(podXID, IsPod)
+		if podUID == "" {
+			log.Printf("Destination pod: %s is not persistet yet", podXID)
+			continue
+		}
+
+		pod := &Pod{
+			ID:    dgraph.ID{UID: podUID, Xid: podXID},
+			Count: counts[index],
+		}
+		pods = append(pods, pod)
+	}
+	return pods
 }

--- a/pkg/controller/dgraph/models/process.go
+++ b/pkg/controller/dgraph/models/process.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/dgraph-io/dgo/protos/api"
@@ -38,21 +39,25 @@ type Proc struct {
 	Name      string    `json:"name,omitempty"`
 	Interacts []*Pod    `json:"interacts,omitempty"`
 	Container Container `json:"container,omitempty"`
+	StartTime time.Time `json:"startTime,omitempty"`
+	EndTime   time.Time `json:"endTime,omitempty"`
 }
 
-func newProc(procXID, procName, containerUID, containerXID string) (*api.Assigned, error) {
+func newProc(procXID, procName, containerUID, containerXID string, creationTimeStamp time.Time) (*api.Assigned, error) {
 	newProc := Proc{
 		ID:        dgraph.ID{Xid: procXID},
 		IsProc:    true,
 		Name:      procName,
 		Container: Container{ID: dgraph.ID{UID: containerUID, Xid: containerXID}},
+		StartTime: creationTimeStamp,
 	}
 	bytes := utils.JSONMarshal(newProc)
 	return dgraph.MutateNode(bytes)
 }
 
 // StoreProcess ...
-func StoreProcess(procXID, procName string, podsXIDs []string, containerXID string) error {
+func StoreProcess(procXID, procName string, podsXIDs []string, containerXID string,
+	creationTimeStamp time.Time) error {
 	containerUID := dgraph.GetUID(containerXID, IsContainer)
 	if containerUID == "" {
 		return fmt.Errorf("Container not persisted yet")
@@ -60,7 +65,7 @@ func StoreProcess(procXID, procName string, podsXIDs []string, containerXID stri
 
 	procUID := dgraph.GetUID(procXID, IsProc)
 	if procUID == "" {
-		assigned, err := newProc(procXID, procName, containerUID, containerXID)
+		assigned, err := newProc(procXID, procName, containerUID, containerXID, creationTimeStamp)
 		if err != nil {
 			logrus.Errorf("Unable to create proc: %s", procXID)
 			return err
@@ -81,6 +86,22 @@ func StoreProcess(procXID, procName string, podsXIDs []string, containerXID stri
 		Interacts: pods,
 	}
 	bytes := utils.JSONMarshal(updatedProc)
+	_, err := dgraph.MutateNode(bytes)
+	return err
+}
+
+func deleteProcessesInTerminatedContainers(containers []*Container) error {
+	procs := []Proc{}
+	for _, container := range containers {
+		for _, proc := range container.Procs {
+			updatedProc := Proc{
+				ID:      dgraph.ID{UID: proc.ID.UID, Xid: proc.ID.Xid},
+				EndTime: container.EndTime,
+			}
+			procs = append(procs, updatedProc)
+		}
+	}
+	bytes := utils.JSONMarshal(procs)
 	_, err := dgraph.MutateNode(bytes)
 	return err
 }

--- a/pkg/controller/dgraph/models/process.go
+++ b/pkg/controller/dgraph/models/process.go
@@ -40,12 +40,12 @@ type Proc struct {
 	Container Container `json:"container,omitempty"`
 }
 
-func newProc(procXID, procName, containerUID string) (*api.Assigned, error) {
+func newProc(procXID, procName, containerUID, containerXID string) (*api.Assigned, error) {
 	newProc := Proc{
 		ID:        dgraph.ID{Xid: procXID},
 		IsProc:    true,
 		Name:      procName,
-		Container: Container{ID: dgraph.ID{UID: containerUID}},
+		Container: Container{ID: dgraph.ID{UID: containerUID, Xid: containerXID}},
 	}
 	bytes := utils.JSONMarshal(newProc)
 	return dgraph.MutateNode(bytes)
@@ -60,7 +60,7 @@ func StoreProcess(procXID, procName string, podsXIDs []string, containerXID stri
 
 	procUID := dgraph.GetUID(procXID, IsProc)
 	if procUID == "" {
-		assigned, err := newProc(procXID, procName, containerUID)
+		assigned, err := newProc(procXID, procName, containerUID, containerXID)
 		if err != nil {
 			logrus.Errorf("Unable to create proc: %s", procXID)
 			return err
@@ -72,12 +72,12 @@ func StoreProcess(procXID, procName string, podsXIDs []string, containerXID stri
 	for _, podXID := range podsXIDs {
 		podUID := dgraph.GetUID(podXID, IsPod)
 		if podUID != "" {
-			pods = append(pods, &Pod{ID: dgraph.ID{UID: podUID}})
+			pods = append(pods, &Pod{ID: dgraph.ID{UID: podUID, Xid: podXID}})
 		}
 	}
 
 	updatedProc := Proc{
-		ID:        dgraph.ID{UID: procUID},
+		ID:        dgraph.ID{UID: procUID, Xid: procXID},
 		Interacts: pods,
 	}
 	bytes := utils.JSONMarshal(updatedProc)

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -49,8 +49,6 @@ func StoreService(service api_v1.Service) error {
 	xid := service.Namespace + ":" + service.Name
 	uid := dgraph.GetUID(xid, IsService)
 
-	svcDeletionTimestamp := service.GetDeletionTimestamp()
-	isDeleted := !svcDeletionTimestamp.IsZero()
 	if uid == "" {
 		newService := Service{
 			Name:      service.Name,
@@ -65,6 +63,9 @@ func StoreService(service api_v1.Service) error {
 		}
 		uid = assigned.Uids["blank-0"]
 	}
+
+	svcDeletionTimestamp := service.GetDeletionTimestamp()
+	isDeleted := !svcDeletionTimestamp.IsZero()
 	if isDeleted {
 		updatedService := Service{
 			ID:      dgraph.ID{Xid: xid, UID: uid},

--- a/pkg/controller/dgraph/purge.go
+++ b/pkg/controller/dgraph/purge.go
@@ -18,11 +18,9 @@
 package dgraph
 
 import (
-	"fmt"
-	"log"
 	"time"
 
-	"github.com/vmware/purser/pkg/controller/utils"
+	log "github.com/Sirupsen/logrus"
 )
 
 type resource struct {
@@ -48,11 +46,8 @@ func removeOldDeletedResources() error {
 		return nil
 	}
 
-	toDelete := utils.JSONMarshal(uids)
-	if toDelete == nil {
-		return fmt.Errorf("Unable to marshal toDelete uids")
-	}
-	return DeleteNodes(toDelete)
+	_, err = MutateNode(uids, DELETE)
+	return err
 }
 
 func retrieveResourcesWithEndTimeBeforeCurrentMonthStart() ([]resource, error) {

--- a/pkg/controller/dgraph/purge.go
+++ b/pkg/controller/dgraph/purge.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgraph
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/vmware/purser/pkg/controller/utils"
+)
+
+type resource struct {
+	ID
+}
+
+// RemoveResourcesInactiveInCurrentMonth deletes all resources which have their deletion time stamp before
+// the start of current month.
+func RemoveResourcesInactiveInCurrentMonth() {
+	err := removeOldDeletedResources()
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+func removeOldDeletedResources() error {
+	uids, err := retrieveResourcesWithEndTimeBeforeCurrentMonthStart()
+	if err != nil {
+		return err
+	}
+	if len(uids) == 0 {
+		log.Println("No old deleted resources are present in dgraph")
+		return nil
+	}
+
+	toDelete := utils.JSONMarshal(uids)
+	if toDelete == nil {
+		return fmt.Errorf("Unable to marshal toDelete uids")
+	}
+	return DeleteNodes(toDelete)
+}
+
+func retrieveResourcesWithEndTimeBeforeCurrentMonthStart() ([]resource, error) {
+	q := `query {
+		resources(func: le(endTime, "` + getCurrentMonthStartTime() + `")) {
+			uid
+		}
+	}`
+
+	type root struct {
+		Resources []resource `json:"resources"`
+	}
+	newRoot := root{}
+	err := ExecuteQuery(q, &newRoot)
+	if err != nil {
+		return nil, err
+	}
+	return newRoot.Resources, nil
+}
+
+// getCurrentMonthStartTime returns month start time as k8s apimachinery Time object
+func getCurrentMonthStartTime() string {
+	now := time.Now()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local)
+	return monthStart.Format(time.RFC3339)
+}

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -86,9 +86,6 @@ func updatePodDetails(group *groups_v1.Group, pod api_v1.Pod, payload controller
 			// This case means we have lost a Delete event for this pod. So we need to update
 			// the pod details with the new one
 		} else if payload.EventType == controller.Delete {
-			// Here we are not using pod.GetObjectMeta().GetDeletionTimestamp() because
-			// by the time controller gets to this part of the code the object(pod) might have been
-			// removed from etcd.
 			existingPodDetails.EndTime = *pod.GetDeletionTimestamp()
 			controller.PvcHandlePodDeletion(existingPodDetails)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Two cases for handling deletion:
1.Soft deletion: When the resource gets deleted from the cluster, update the deletion time stamp for that resource in the dgraph.
2. Hard deletion: Delete the resource from dgraph, if the resource's deletion time stamp is from previous months.

Run this logic daily once(cron go routine).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #43 

**Special notes for your reviewer**:
Tested the logic for my minikube cluster, with go routine running every 1 min instead of daily just for testing purpose. It was working as expected.
