### PR TITLE
(#53) Optimize: evaluation for pod interactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,18 @@
+# Copyright (c) 2018 VMware Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # The binary to build (just the basename).
 BIN := controller
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Purser extension for K8s
 [![Build Status](https://travis-ci.org/vmware/purser.svg?branch=master)](https://travis-ci.org/vmware/purser)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vmware/purser)](https://goreportcard.com/report/github.com/vmware/purser)
 
 Cost visbility for Kubernetes based Cloud Native Applications.
 

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/vmware/purser/pkg/client"
 	group_client "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
 	subscriber_client "github.com/vmware/purser/pkg/client/clientset/typed/subscriber/v1"
@@ -29,13 +31,20 @@ import (
 	"github.com/vmware/purser/pkg/utils"
 )
 
+// InClusterConfigPath should be empty to get client and config for InCluster environment.
+const InClusterConfigPath = ""
+
 // Setup initialzes the controller configuration
 func Setup(conf *controller.Config) {
-	kubeconfig := flag.String("kubeconfig", "", "path to the kubeconfig file")
+	kubeconfig := flag.String("kubeconfig", InClusterConfigPath, "path to the kubeconfig file")
 	flag.Parse()
-
+	var err error
 	*conf = controller.Config{}
-	conf.Kubeclient = utils.GetKubeclient(*kubeconfig)
+	conf.KubeConfig, err = utils.GetKubeconfig(*kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	conf.Kubeclient = utils.GetKubeclient(conf.KubeConfig)
 	conf.Resource = controller.Resource{
 		Pod:                   true,
 		Node:                  true,

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package config
 
 import (

--- a/cmd/plugin/purser.go
+++ b/cmd/plugin/purser.go
@@ -37,7 +37,11 @@ func init() {
 	kubeconfig := flag.String("kubeconfig", os.Getenv("KUBECTL_PLUGINS_GLOBAL_FLAG_KUBECONFIG"), "path to Kubernetes config file")
 	flag.Parse()
 
-	plugin.ProvideClientSetInstance(utils.GetKubeclient(*kubeconfig))
+	config, err := utils.GetKubeconfig(*kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	plugin.ProvideClientSetInstance(utils.GetKubeclient(config))
 
 	client, clusterConfig := client.GetAPIExtensionClient(*kubeconfig)
 	groupClient = groups_client_v1.NewGroupClient(client, clusterConfig)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controller
 
 import (

--- a/pkg/controller/dgraph/dgraph.go
+++ b/pkg/controller/dgraph/dgraph.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/dgraph-io/dgo"
 	"github.com/dgraph-io/dgo/protos/api"
-	"github.com/robfig/cron"
 	"github.com/vmware/purser/pkg/controller/utils"
 	"google.golang.org/grpc"
 )
@@ -60,7 +59,6 @@ func init() {
 	if err != nil {
 		fmt.Println("Error while creating schema ", err)
 	}
-	startCronGoRoutines()
 }
 
 // Open creates and establishes a new Dgraph connection
@@ -184,13 +182,4 @@ func unmarshalDgraphResponse(resp *api.Response, id string) string {
 	}
 
 	return r.IDs[0].UID
-}
-
-func startCronGoRoutines() {
-	c := cron.New()
-	err := c.AddFunc("@daily", RemoveResourcesInactiveInCurrentMonth)
-	if err != nil {
-		log.Println(err)
-	}
-	c.Start()
 }

--- a/pkg/controller/discovery/executer/exec.go
+++ b/pkg/controller/discovery/executer/exec.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package executer
 
 import (

--- a/pkg/controller/discovery/executer/exec.go
+++ b/pkg/controller/discovery/executer/exec.go
@@ -24,21 +24,18 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/purser/pkg/utils"
+	"github.com/vmware/purser/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-const debug = false
-
 // ExecToPodThroughAPI uninterractively exec to the pod with the command specified.
-func ExecToPodThroughAPI(client *kubernetes.Clientset, command, containerName, podName string, stdin io.Reader) (string, string, error) {
+func ExecToPodThroughAPI(conf controller.Config, command, containerName, podName string, stdin io.Reader) (string, string, error) {
 	// Prepare the API URL used to execute another process within the Pod. In this case,
 	// we'll run a remote shell.
-	req := client.CoreV1().RESTClient().Post().
+	req := conf.Kubeclient.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podName).
 		SubResource("exec")
@@ -58,15 +55,9 @@ func ExecToPodThroughAPI(client *kubernetes.Clientset, command, containerName, p
 		TTY:       false,
 	}, parameterCodec)
 
-	if debug {
-		log.Debug("Request URL:", req.URL().String())
-	}
+	log.Debug("Request URL:", req.URL().String())
 
-	config, err := utils.GetKubeconfig("")
-	if err != nil {
-		return "", "", fmt.Errorf("failed to fetch kubeconfig file %v", err)
-	}
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(conf.KubeConfig, "POST", req.URL())
 	if err != nil {
 		return "", "", fmt.Errorf("error while creating Executor: %v", err)
 	}

--- a/pkg/controller/discovery/linker/podlinks.go
+++ b/pkg/controller/discovery/linker/podlinks.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package linker
 
 import (

--- a/pkg/controller/discovery/processor/cluster.go
+++ b/pkg/controller/discovery/processor/cluster.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package processor
 
 import (

--- a/pkg/controller/discovery/processor/container.go
+++ b/pkg/controller/discovery/processor/container.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware/purser/pkg/controller"
 	"github.com/vmware/purser/pkg/controller/discovery/linker"
 
 	log "github.com/Sirupsen/logrus"
@@ -28,27 +29,24 @@ import (
 	"github.com/vmware/purser/pkg/controller/utils"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
-const debug = false
-
-func processContainerDetails(client *kubernetes.Clientset, pod corev1.Pod,
+func processContainerDetails(conf controller.Config, pod corev1.Pod,
 	containers []corev1.Container) map[string](map[string]float64) {
 	podInteractions := make(map[string](map[string]float64))
 	for _, container := range containers {
-		pidList, cmdList := getPIDList(client, container.Name, pod.Name)
+		pidList, cmdList := getPIDList(conf, container.Name, pod.Name)
 		for index, pid := range pidList {
 			process := linker.Process{ID: pid, Name: cmdList[index]}
-			getProcessDump(client, pod, container.Name, process, podInteractions)
+			getProcessDump(conf, pod, container.Name, process, podInteractions)
 		}
 	}
 	return podInteractions
 }
 
-func getPIDList(client *kubernetes.Clientset, containerName, podName string) ([]string, []string) {
+func getPIDList(conf controller.Config, containerName, podName string) ([]string, []string) {
 	command := "ps -A -o pid,cmd"
-	output, err := executeCommandInPod(client, command, containerName, podName)
+	output, err := executeCommandInPod(conf, command, containerName, podName)
 	if err != nil {
 		return nil, nil
 	}
@@ -67,12 +65,12 @@ func getPIDList(client *kubernetes.Clientset, containerName, podName string) ([]
 	return pidList[1:], cmdList[1:]
 }
 
-func getProcessDump(client *kubernetes.Clientset, pod corev1.Pod, containerName string,
+func getProcessDump(conf controller.Config, pod corev1.Pod, containerName string,
 	process linker.Process, podInteractions map[string](map[string]float64)) {
 	//get tcp information from /proc/pid/net/tcp for each process
 	if process.ID != "" {
 		tcpCommand := "cat /proc/" + process.ID + "/net/tcp"
-		tcpOutput, err := executeCommandInPod(client, tcpCommand, containerName, pod.Name)
+		tcpOutput, err := executeCommandInPod(conf, tcpCommand, containerName, pod.Name)
 		if err != nil {
 			//to clean dump only to have required fields
 			tcpDump := utils.PurgeTCPData(tcpOutput)
@@ -80,7 +78,7 @@ func getProcessDump(client *kubernetes.Clientset, pod corev1.Pod, containerName 
 		}
 
 		tcp6Command := "cat /proc/" + process.ID + "/net/tcp6"
-		tcp6Output, err := executeCommandInPod(client, tcp6Command, containerName, pod.Name)
+		tcp6Output, err := executeCommandInPod(conf, tcp6Command, containerName, pod.Name)
 		if err != nil {
 			//to clean dump only to have required fields
 			tcp6Dump := utils.PurgeTCP6Data(tcp6Output)
@@ -89,10 +87,10 @@ func getProcessDump(client *kubernetes.Clientset, pod corev1.Pod, containerName 
 	}
 }
 
-func executeCommandInPod(client *kubernetes.Clientset, command, containerName, podName string) (string, error) {
-	output, stderr, err := executer.ExecToPodThroughAPI(client, command, containerName, podName, nil)
+func executeCommandInPod(conf controller.Config, command, containerName, podName string) (string, error) {
+	output, stderr, err := executer.ExecToPodThroughAPI(conf, command, containerName, podName, nil)
 
-	if err != nil && debug {
+	if err != nil {
 		log.Debugf("Failed `exec`ing to the container %q, command %q Error: %+v", podName, command, err)
 	}
 

--- a/pkg/controller/discovery/processor/container.go
+++ b/pkg/controller/discovery/processor/container.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package processor
 
 import (

--- a/pkg/controller/discovery/processor/pod.go
+++ b/pkg/controller/discovery/processor/pod.go
@@ -41,9 +41,9 @@ func processPodDetails(client *kubernetes.Clientset, pods *corev1.PodList) {
 				defer wg.Done()
 
 				containers := pod.Spec.Containers
-				processContainerDetails(client, pod, containers)
+				podInteractions := processContainerDetails(client, pod, containers)
+				linker.UpdatePodToPodTable(podInteractions)
 				log.Debugf("Finished processing Pod (%d/%d)", index+1, podsCount)
-
 			}(pod, index)
 		}
 	}

--- a/pkg/controller/discovery/processor/pod.go
+++ b/pkg/controller/discovery/processor/pod.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package processor
 
 import (

--- a/pkg/controller/discovery/processor/pod.go
+++ b/pkg/controller/discovery/processor/pod.go
@@ -28,24 +28,23 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 var wg sync.WaitGroup
 
 // ProcessPodInteractions fetches details of all the running processes in each container of
 // each pod in a given namespace and generates a 1:1 mapping between the communicating pods.
-func ProcessPodInteractions(conf *controller.Config) {
+func ProcessPodInteractions(conf controller.Config) {
 	k8sPods := RetrievePodList(conf.Kubeclient, metav1.ListOptions{})
 
 	linker.PopulatePodIPTable(k8sPods)
-	processPodDetails(conf.Kubeclient, k8sPods)
+	processPodDetails(conf, k8sPods)
 
 	linker.GenerateAndStorePodInteractions()
 	log.Infof("Successfully generated Pod To Pod mapping.")
 }
 
-func processPodDetails(client *kubernetes.Clientset, pods *corev1.PodList) {
+func processPodDetails(conf controller.Config, pods *corev1.PodList) {
 	podsCount := len(pods.Items)
 	log.Infof("Processing total of (%d) Pods.", podsCount)
 
@@ -58,7 +57,7 @@ func processPodDetails(client *kubernetes.Clientset, pods *corev1.PodList) {
 				defer wg.Done()
 
 				containers := pod.Spec.Containers
-				podInteractions := processContainerDetails(client, pod, containers)
+				podInteractions := processContainerDetails(conf, pod, containers)
 				linker.UpdatePodToPodTable(podInteractions)
 				log.Debugf("Finished processing Pod (%d/%d)", index+1, podsCount)
 			}(pod, index)

--- a/pkg/controller/eventprocessor/processor.go
+++ b/pkg/controller/eventprocessor/processor.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package eventprocessor
 
 import (

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -22,6 +22,7 @@ import (
 	subscriber_v1 "github.com/vmware/purser/pkg/client/clientset/typed/subscriber/v1"
 	"github.com/vmware/purser/pkg/controller/buffering"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // These are the event types supported for controllers
@@ -47,6 +48,7 @@ type Resource struct {
 
 // Config contains config objects
 type Config struct {
+	KubeConfig       *rest.Config
 	Resource         Resource `json:"resource"`
 	RingBuffer       *buffering.RingBuffer
 	Groupcrdclient   *groups_v1.GroupClient

--- a/pkg/controller/utils/purge.go
+++ b/pkg/controller/utils/purge.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import (

--- a/pkg/utils/fileutils.go
+++ b/pkg/utils/fileutils.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import (

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -26,12 +26,7 @@ import (
 
 // GetKubeclient returns a k8s clientset from the kubeconfig, if nil fallback to
 // client from inCluster config.
-func GetKubeclient(kubeconfigPath string) *kubernetes.Clientset {
-	config, err := GetKubeconfig(kubeconfigPath)
-	if err != nil {
-		logrus.Fatalf("failed to geeeet kubernetes config: %v", err)
-	}
-
+func GetKubeclient(config *rest.Config) *kubernetes.Clientset {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		logrus.Fatalf("failed to create kubernetes clientset: %v", err)

--- a/pkg/utils/logutil.go
+++ b/pkg/utils/logutil.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Instead of updating the global variable `podToPodTable` for each line of tcp dump, we can combine all pod interaction data for a given pod and then acquire lock for `podToPodTable` and update it. This will acquire lock at most once per pod.

1. add license to missing files and add go report card for the project

1. Made discovery as a cron job. Cluster configuration is needed at many places and hence we were evaluating it every time. Modified the code so that now the cluster configuration is saved and used whenever it is needed.

**Which issue(s) this PR fixes**:
Fixes #53 
