### PR TITLE
fix(#56): error condition and namespace issue.

### DIFF
--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -18,8 +18,6 @@
 package main
 
 import (
-	"time"
-
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/robfig/cron"
@@ -40,14 +38,11 @@ func init() {
 
 func main() {
 	go eventprocessor.ProcessEvents(&conf)
-	controller.Start(&conf)
 	startCronJobs()
+	controller.Start(&conf)
 }
 
 func startCronJobs() {
-	// wait for the inventory process to complete
-	time.Sleep(time.Minute * 2)
-
 	c := cron.New()
 	err := c.AddFunc("@every 0h30m", runDiscovery)
 	if err != nil {

--- a/pkg/controller/discovery/executer/exec.go
+++ b/pkg/controller/discovery/executer/exec.go
@@ -32,12 +32,13 @@ import (
 )
 
 // ExecToPodThroughAPI uninterractively exec to the pod with the command specified.
-func ExecToPodThroughAPI(conf controller.Config, command, containerName, podName string, stdin io.Reader) (string, string, error) {
+func ExecToPodThroughAPI(conf controller.Config, pod corev1.Pod, command, containerName string, stdin io.Reader) (string, string, error) {
 	// Prepare the API URL used to execute another process within the Pod. In this case,
 	// we'll run a remote shell.
 	req := conf.Kubeclient.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Name(podName).
+		Name(pod.Name).
+		Namespace(pod.Namespace).
 		SubResource("exec")
 
 	scheme := runtime.NewScheme()

--- a/pkg/controller/discovery/processor/container.go
+++ b/pkg/controller/discovery/processor/container.go
@@ -35,7 +35,7 @@ func processContainerDetails(conf controller.Config, pod corev1.Pod,
 	containers []corev1.Container) map[string](map[string]float64) {
 	podInteractions := make(map[string](map[string]float64))
 	for _, container := range containers {
-		pidList, cmdList := getPIDList(conf, container.Name, pod.Name)
+		pidList, cmdList := getPIDList(conf, pod, container.Name)
 		for index, pid := range pidList {
 			process := linker.Process{ID: pid, Name: cmdList[index]}
 			getProcessDump(conf, pod, container.Name, process, podInteractions)
@@ -44,16 +44,16 @@ func processContainerDetails(conf controller.Config, pod corev1.Pod,
 	return podInteractions
 }
 
-func getPIDList(conf controller.Config, containerName, podName string) ([]string, []string) {
+func getPIDList(conf controller.Config, pod corev1.Pod, containerName string) ([]string, []string) {
 	command := "ps -A -o pid,cmd"
-	output, err := executeCommandInPod(conf, command, containerName, podName)
+	output, err := executeCommandInPod(conf, pod, command, containerName)
 	if err != nil {
 		return nil, nil
 	}
 
 	pidCMDList := strings.Split(output, "\n")
-	var pidList, cmdList []string
 
+	var pidList, cmdList []string
 	for _, pidCMD := range pidCMDList {
 		if pidCMD != "" {
 			pidCMDClean := strings.Split((strings.TrimSpace(pidCMD)), " ")
@@ -70,16 +70,16 @@ func getProcessDump(conf controller.Config, pod corev1.Pod, containerName string
 	//get tcp information from /proc/pid/net/tcp for each process
 	if process.ID != "" {
 		tcpCommand := "cat /proc/" + process.ID + "/net/tcp"
-		tcpOutput, err := executeCommandInPod(conf, tcpCommand, containerName, pod.Name)
-		if err != nil {
+		tcpOutput, err := executeCommandInPod(conf, pod, tcpCommand, containerName)
+		if err == nil {
 			//to clean dump only to have required fields
 			tcpDump := utils.PurgeTCPData(tcpOutput)
 			linker.PopulateMappingTables(tcpDump, pod, containerName, podInteractions)
 		}
 
 		tcp6Command := "cat /proc/" + process.ID + "/net/tcp6"
-		tcp6Output, err := executeCommandInPod(conf, tcp6Command, containerName, pod.Name)
-		if err != nil {
+		tcp6Output, err := executeCommandInPod(conf, pod, tcp6Command, containerName)
+		if err == nil {
 			//to clean dump only to have required fields
 			tcp6Dump := utils.PurgeTCP6Data(tcp6Output)
 			linker.PopulateMappingTables(tcp6Dump, pod, containerName, podInteractions)
@@ -87,11 +87,11 @@ func getProcessDump(conf controller.Config, pod corev1.Pod, containerName string
 	}
 }
 
-func executeCommandInPod(conf controller.Config, command, containerName, podName string) (string, error) {
-	output, stderr, err := executer.ExecToPodThroughAPI(conf, command, containerName, podName, nil)
+func executeCommandInPod(conf controller.Config, pod corev1.Pod, command, containerName string) (string, error) {
+	output, stderr, err := executer.ExecToPodThroughAPI(conf, pod, command, containerName, nil)
 
 	if err != nil {
-		log.Debugf("Failed `exec`ing to the container %q, command %q Error: %+v", podName, command, err)
+		log.Debugf("Failed `exec`ing to the container %q, command %q Error: %+v", pod.Name, command, err)
 	}
 
 	if len(stderr) > 0 {

--- a/pkg/controller/eventprocessor/processor.go
+++ b/pkg/controller/eventprocessor/processor.go
@@ -48,7 +48,7 @@ func ProcessEvents(conf *controller.Config) {
 			}
 
 			// Persist in dgraph
-			//PersistPayloads(data)
+			PersistPayloads(data)
 
 			// Post data to subscribers.
 			notifySubscribers(data, subscribers)


### PR DESCRIPTION
Pod interactions were not showing in Dgraph. This PR makes the following changes to fix the issue:

- adds missing `namespace` field in the exec command.
- fixes the misplaced persistence logic.
- enables the commented `PersistPayload` code in eventprocessor.

Fixes #56 

