### PR TITLE
fix #60: Persist service interactions

### DIFF
--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -95,6 +95,7 @@ func storeContainerIfNotExist(c api_v1.Container, pod api_v1.Pod, podUID string)
 			log.Errorf("Unable to create container: %s", containerXid)
 			return container, err
 		}
+		log.Infof("Container with xid: (%s) persisted in dgraph", containerXid)
 		containerUID = assigned.Uids["blank-0"]
 	}
 

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -69,6 +69,7 @@ func StorePod(k8sPod api_v1.Pod) error {
 		if err != nil {
 			return err
 		}
+		log.Infof("Pod with xid: (%s) persisted in dgraph", xid)
 		uid = assigned.Uids["blank-0"]
 	}
 

--- a/pkg/controller/dgraph/models/process.go
+++ b/pkg/controller/dgraph/models/process.go
@@ -69,6 +69,7 @@ func StoreProcess(procName, containerXID string, podsXIDs []string, creationTime
 			logrus.Errorf("Unable to create proc: %s", procXID)
 			return err
 		}
+		log.Infof("Process with xid: (%s) persisted in dgraph", procXID)
 		procUID = assigned.Uids["blank-0"]
 	}
 

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -39,7 +39,7 @@ type Service struct {
 	Name      string     `json:"name,omitempty"`
 	StartTime time.Time  `json:"startTime,omitempty"`
 	EndTime   time.Time  `json:"endTime,omitempty"`
-	Pod       []*Pod     `json:"servicePods,omitempty"`
+	Pod       []*Pod     `json:"pod,omitempty"`
 	Interacts []*Service `json:"interacts,omitempty"`
 }
 
@@ -63,6 +63,7 @@ func StoreService(service api_v1.Service) error {
 		if err != nil {
 			return err
 		}
+		log.Infof("Service with xid: (%s) persisted in dgraph", xid)
 		uid = assigned.Uids["blank-0"]
 	}
 
@@ -107,7 +108,7 @@ func StorePodServiceEdges(svcXID string, podsXIDsInService []string) error {
 		_, err := dgraph.MutateNode(updatedService, dgraph.UPDATE)
 		return err
 	}
-	return nil
+	return fmt.Errorf("Service with xid: (%s) not in dgraph", svcXID)
 }
 
 // RetrieveAllServices returns all pods in the dgraph
@@ -140,6 +141,7 @@ func RetrieveAllServices() ([]Service, error) {
 func RetrieveAllServicesWithDstPods() ([]Service, error) {
 	const q = `query {
 		services(func: has(isService)) {
+			xid
 			name
 			pod {
 				name


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #60
Previously while marshaling the service, the pods in it are under `servicePods` field. But we were trying to unmarshal it back to `pod` field.
