### PR TITLE
api for first level data of cluster hierarchy

### DIFF
--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -59,7 +59,7 @@ func GetClusterHierarchy(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	logrus.Debugf("Query params: (%v)", queryParams)
 
-	var jsonData query.JsonDataWrapper
+	var jsonData query.JSONDataWrapper
 	if view, isView := queryParams[query.View]; isView && view[0] == query.Physical {
 		jsonData = query.RetrieveClusterHierarchy(query.Physical)
 	} else {

--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -18,6 +18,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
@@ -40,16 +41,31 @@ func GetPodInteractions(w http.ResponseWriter, r *http.Request) {
 	logrus.Debugf("Query params: (%v)", queryParams)
 
 	var jsonResp []byte
-	if name, isName := queryParams["name"]; isName {
+	if name, isName := queryParams[query.Name]; isName {
 		jsonResp = query.RetrievePodsInteractions(name[0], false)
 	} else {
-		if orphanVal, isOrphan := queryParams["orphan"]; isOrphan && orphanVal[0] == "false" {
-			jsonResp = query.RetrievePodsInteractions("", false)
+		if orphanVal, isOrphan := queryParams[query.Orphan]; isOrphan && orphanVal[0] == query.False {
+			jsonResp = query.RetrievePodsInteractions(query.AllPods, false)
 		} else {
-			jsonResp = query.RetrievePodsInteractions("", true)
+			jsonResp = query.RetrievePodsInteractions(query.AllPods, true)
 		}
 	}
 	writeBytes(w, jsonResp)
+}
+
+// GetClusterHierarchy listens on /hierarchy endpoint and returns all namespaces(or nodes and PV) in the cluster
+func GetClusterHierarchy(w http.ResponseWriter, r *http.Request) {
+	addHeaders(&w, r)
+	queryParams := r.URL.Query()
+	logrus.Debugf("Query params: (%v)", queryParams)
+
+	var jsonData query.JsonDataWrapper
+	if view, isView := queryParams[query.View]; isView && view[0] == query.Physical {
+		jsonData = query.RetrieveClusterHierarchy(query.Physical)
+	} else {
+		jsonData = query.RetrieveClusterHierarchy(query.Logical)
+	}
+	encodeAndWrite(w, jsonData)
 }
 
 func addHeaders(w *http.ResponseWriter, r *http.Request) {
@@ -61,6 +77,13 @@ func addHeaders(w *http.ResponseWriter, r *http.Request) {
 
 func writeBytes(w io.Writer, data []byte) {
 	_, err := w.Write(data)
+	if err != nil {
+		logrus.Errorf("Unable to encode to json: (%v)", err)
+	}
+}
+
+func encodeAndWrite(w io.Writer, obj interface{}) {
+	err := json.NewEncoder(w).Encode(obj)
 	if err != nil {
 		logrus.Errorf("Unable to encode to json: (%v)", err)
 	}

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -135,7 +135,7 @@ func StorePodsInteraction(sourcePodXID string, destinationPodsXIDs []string, cou
 
 	pods := retrievePodsWithCountAsEdgeWeightFromPodsXIDs(destinationPodsXIDs, counts)
 	source := Pod{
-		ID:        dgraph.ID{UID: uid, Xid: sourcePodXID},
+		ID:   dgraph.ID{UID: uid, Xid: sourcePodXID},
 		Pods: pods,
 	}
 	_, err := dgraph.MutateNode(source, dgraph.UPDATE)

--- a/pkg/controller/dgraph/models/query/cluster.go
+++ b/pkg/controller/dgraph/models/query/cluster.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package query
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+)
+
+// RetrieveClusterHierarchy returns all namespaces if view is logical and returns all nodes with disks if view is physical
+func RetrieveClusterHierarchy(view string) JsonDataWrapper {
+	var query string
+	if view == Physical {
+		query = `query {
+			children(func: has(name)) @filter(has(isNode) OR has(isPersistentVolume)) {
+				name
+				type
+			}
+		}`
+	} else {
+		query = `query {
+			children(func: has(isNamespace)) {
+				name
+				type
+			}
+		}`
+	}
+
+	parentRoot := Parent{}
+	err := dgraph.ExecuteQuery(query, &parentRoot)
+	if err != nil {
+		logrus.Errorf("Unable to execute query for retrieving cluster hierarchy: (%v)", err)
+		return JsonDataWrapper{}
+	}
+	root := JsonDataWrapper{
+		Data: Parent{
+			Name:     "cluster",
+			Type:     "cluster",
+			Children: parentRoot.Children,
+		},
+	}
+	logrus.Debugf("data: (%v)", root.Data)
+	return root
+}

--- a/pkg/controller/dgraph/models/query/cluster.go
+++ b/pkg/controller/dgraph/models/query/cluster.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RetrieveClusterHierarchy returns all namespaces if view is logical and returns all nodes with disks if view is physical
-func RetrieveClusterHierarchy(view string) JsonDataWrapper {
+func RetrieveClusterHierarchy(view string) JSONDataWrapper {
 	var query string
 	if view == Physical {
 		query = `query {
@@ -45,9 +45,9 @@ func RetrieveClusterHierarchy(view string) JsonDataWrapper {
 	err := dgraph.ExecuteQuery(query, &parentRoot)
 	if err != nil {
 		logrus.Errorf("Unable to execute query for retrieving cluster hierarchy: (%v)", err)
-		return JsonDataWrapper{}
+		return JSONDataWrapper{}
 	}
-	root := JsonDataWrapper{
+	root := JSONDataWrapper{
 		Data: Parent{
 			Name:     "cluster",
 			Type:     "cluster",

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -25,7 +25,7 @@ import (
 // RetrievePodsInteractions returns inbound and outbound interactions of a pod
 func RetrievePodsInteractions(name string, isOrphan bool) []byte {
 	var query string
-	if name == "" {
+	if name == AllPods {
 		if isOrphan {
 			query = `query {
 				pods(func: has(isPod)) {

--- a/pkg/controller/dgraph/models/query/types.go
+++ b/pkg/controller/dgraph/models/query/types.go
@@ -15,40 +15,33 @@
  * limitations under the License.
  */
 
-package api
+package query
 
-import (
-	"net/http"
+// Constants used in query parameters
+const (
+	AllPods  = ""
+	Name     = "name"
+	Orphan   = "orphan"
+	View     = "view"
+	Physical = "physical"
+	Logical  = "logical"
+	False    = "false"
 )
 
-// Route structure
-type Route struct {
-	Name        string
-	Method      string
-	Pattern     string
-	HandlerFunc http.HandlerFunc
+// Children structure
+type Children struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
-// Routes list
-type Routes []Route
+// Parent structure
+type Parent struct {
+	Name     string     `json:"name,omitempty"`
+	Type     string     `json:"type,omitempty"`
+	Children []Children `json:"children,omitempty"`
+}
 
-var routes = Routes{
-	Route{
-		"GetHomePage",
-		"GET",
-		"/",
-		GetHomePage,
-	},
-	Route{
-		"GetPodInteractions",
-		"GET",
-		"/interactions/pod",
-		GetPodInteractions,
-	},
-	Route{
-		"GetClusterHierarchy",
-		"GET",
-		"/hierarchy",
-		GetClusterHierarchy,
-	},
+// JsonDataWrapper structure
+type JsonDataWrapper struct {
+	Data Parent `json:"data,omitempty"`
 }

--- a/pkg/controller/dgraph/models/query/types.go
+++ b/pkg/controller/dgraph/models/query/types.go
@@ -41,7 +41,7 @@ type Parent struct {
 	Children []Children `json:"children,omitempty"`
 }
 
-// JsonDataWrapper structure
-type JsonDataWrapper struct {
+// JSONDataWrapper structure
+type JSONDataWrapper struct {
 	Data Parent `json:"data,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
API endpoint `/hierarchy` with option of selecting view(physical or logical).

**Which issue(s) this PR fixes** :
Fixes a task in #46 

