### PR TITLE
fix bug in storing timestamps in dgraph

### DIFF
--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -39,8 +39,8 @@ type Container struct {
 	dgraph.ID
 	IsContainer   bool       `json:"isContainer,omitempty"`
 	Name          string     `json:"name,omitempty"`
-	StartTime     time.Time  `json:"startTime,omitempty"`
-	EndTime       time.Time  `json:"endTime,omitempty"`
+	StartTime     string     `json:"startTime,omitempty"`
+	EndTime       string     `json:"endTime,omitempty"`
 	Pod           Pod        `json:"pod,omitempty"`
 	Procs         []*Proc    `json:"procs,omitempty"`
 	Namespace     *Namespace `json:"namespace,omitempty"`
@@ -60,7 +60,7 @@ func newContainer(container api_v1.Container, podUID, namespaceUID string, pod a
 		Name:          container.Name,
 		IsContainer:   true,
 		Type:          "container",
-		StartTime:     pod.GetCreationTimestamp().Time,
+		StartTime:     pod.GetCreationTimestamp().Time.Format(time.RFC3339),
 		Pod:           Pod{ID: dgraph.ID{UID: podUID, Xid: pod.Namespace + ":" + pod.Name}},
 		CPURequest:    utils.ConvertToFloat64CPU(requests.Cpu()),
 		CPULimit:      utils.ConvertToFloat64CPU(limits.Cpu()),
@@ -141,7 +141,7 @@ func storeContainerIfNotExist(c api_v1.Container, pod api_v1.Pod, podUID, namesp
 
 func deleteContainersInTerminatedPod(containers []*Container, endTime time.Time) {
 	for _, container := range containers {
-		container.EndTime = endTime
+		container.EndTime = endTime.Format(time.RFC3339)
 	}
 	_, err := dgraph.MutateNode(containers, dgraph.UPDATE)
 	if err != nil {

--- a/pkg/controller/dgraph/models/deployment.go
+++ b/pkg/controller/dgraph/models/deployment.go
@@ -35,8 +35,8 @@ type Deployment struct {
 	dgraph.ID
 	IsDeployment bool       `json:"isDeployment,omitempty"`
 	Name         string     `json:"name,omitempty"`
-	StartTime    time.Time  `json:"startTime,omitempty"`
-	EndTime      time.Time  `json:"endTime,omitempty"`
+	StartTime    string     `json:"startTime,omitempty"`
+	EndTime      string     `json:"endTime,omitempty"`
 	Namespace    *Namespace `json:"namespace,omitempty"`
 	Pods         []*Pod     `json:"pods,omitempty"`
 	Type         string     `json:"type,omitempty"`
@@ -48,7 +48,7 @@ func createDeploymentObject(deployment apps_v1beta1.Deployment) Deployment {
 		IsDeployment: true,
 		Type:         "deployment",
 		ID:           dgraph.ID{Xid: deployment.Namespace + ":" + deployment.Name},
-		StartTime:    deployment.GetCreationTimestamp().Time,
+		StartTime:    deployment.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	namespaceUID := CreateOrGetNamespaceByID(deployment.Namespace)
 	if namespaceUID != "" {
@@ -56,7 +56,7 @@ func createDeploymentObject(deployment apps_v1beta1.Deployment) Deployment {
 	}
 	deploymentDeletionTimestamp := deployment.GetDeletionTimestamp()
 	if !deploymentDeletionTimestamp.IsZero() {
-		newDeployment.EndTime = deploymentDeletionTimestamp.Time
+		newDeployment.EndTime = deploymentDeletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newDeployment
 }

--- a/pkg/controller/dgraph/models/job.go
+++ b/pkg/controller/dgraph/models/job.go
@@ -30,7 +30,7 @@ const (
 	IsJob = "isJob"
 )
 
-// Daemonset schema in dgraph
+// Job schema in dgraph
 type Job struct {
 	dgraph.ID
 	IsJob     bool       `json:"isJob,omitempty"`

--- a/pkg/controller/dgraph/models/namespace.go
+++ b/pkg/controller/dgraph/models/namespace.go
@@ -35,11 +35,11 @@ const (
 // Namespace schema in dgraph
 type Namespace struct {
 	dgraph.ID
-	IsNamespace bool      `json:"isNamespace,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	StartTime   time.Time `json:"startTime,omitempty"`
-	EndTime     time.Time `json:"endTime,omitempty"`
-	Type        string    `json:"type,omitempty"`
+	IsNamespace bool   `json:"isNamespace,omitempty"`
+	Name        string `json:"name,omitempty"`
+	StartTime   string `json:"startTime,omitempty"`
+	EndTime     string `json:"endTime,omitempty"`
+	Type        string `json:"type,omitempty"`
 }
 
 func newNamespace(namespace api_v1.Namespace) Namespace {
@@ -48,11 +48,11 @@ func newNamespace(namespace api_v1.Namespace) Namespace {
 		Name:        namespace.Name,
 		IsNamespace: true,
 		Type:        "namespace",
-		StartTime:   namespace.GetCreationTimestamp().Time,
+		StartTime:   namespace.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	nsDeletionTimestamp := namespace.GetDeletionTimestamp()
 	if !nsDeletionTimestamp.IsZero() {
-		ns.EndTime = nsDeletionTimestamp.Time
+		ns.EndTime = nsDeletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return ns
 }

--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -36,14 +36,14 @@ const (
 // Node schema in dgraph
 type Node struct {
 	dgraph.ID
-	IsNode         bool      `json:"isNode,omitempty"`
-	Name           string    `json:"name,omitempty"`
-	StartTime      time.Time `json:"startTime,omitempty"`
-	EndTime        time.Time `json:"endTime,omitempty"`
-	Pods           []*Pod    `json:"pods,omitempty"`
-	CPUCapity      float64   `json:"cpuCapacity,omitempty"`
-	MemoryCapacity float64   `json:"memoryCapacity,omitempty"`
-	Type           string    `json:"type,omitempty"`
+	IsNode         bool    `json:"isNode,omitempty"`
+	Name           string  `json:"name,omitempty"`
+	StartTime      string  `json:"startTime,omitempty"`
+	EndTime        string  `json:"endTime,omitempty"`
+	Pods           []*Pod  `json:"pods,omitempty"`
+	CPUCapity      float64 `json:"cpuCapacity,omitempty"`
+	MemoryCapacity float64 `json:"memoryCapacity,omitempty"`
+	Type           string  `json:"type,omitempty"`
 }
 
 func createNodeObject(node api_v1.Node) Node {
@@ -52,13 +52,13 @@ func createNodeObject(node api_v1.Node) Node {
 		IsNode:         true,
 		Type:           "node",
 		ID:             dgraph.ID{Xid: node.Name},
-		StartTime:      node.GetCreationTimestamp().Time,
+		StartTime:      node.GetCreationTimestamp().Time.Format(time.RFC3339),
 		CPUCapity:      utils.ConvertToFloat64CPU(node.Status.Capacity.Cpu()),
 		MemoryCapacity: utils.ConvertToFloat64GB(node.Status.Capacity.Memory()),
 	}
 	nodeDeletionTimestamp := node.GetDeletionTimestamp()
 	if !nodeDeletionTimestamp.IsZero() {
-		newNode.EndTime = nodeDeletionTimestamp.Time
+		newNode.EndTime = nodeDeletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newNode
 }

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -39,8 +39,8 @@ type Pod struct {
 	dgraph.ID
 	IsPod         bool         `json:"isPod,omitempty"`
 	Name          string       `json:"name,omitempty"`
-	StartTime     time.Time    `json:"startTime,omitempty"`
-	EndTime       time.Time    `json:"endTime,omitempty"`
+	StartTime     string       `json:"startTime,omitempty"`
+	EndTime       string       `json:"endTime,omitempty"`
 	Containers    []*Container `json:"containers,omitempty"`
 	Pods          []*Pod       `json:"pod,omitempty"`
 	Count         float64      `json:"pod|count,omitempty"`
@@ -73,7 +73,7 @@ func newPod(k8sPod api_v1.Pod) (*api.Assigned, error) {
 		IsPod:     true,
 		Type:      "pod",
 		ID:        dgraph.ID{Xid: k8sPod.Namespace + ":" + k8sPod.Name},
-		StartTime: k8sPod.GetCreationTimestamp().Time,
+		StartTime: k8sPod.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	nodeUID, err := createOrGetNodeByID(k8sPod.Spec.NodeName)
 	if err == nil {
@@ -107,7 +107,7 @@ func StorePod(k8sPod api_v1.Pod) error {
 	if !podDeletedTimestamp.IsZero() {
 		pod = Pod{
 			ID:      dgraph.ID{Xid: xid, UID: uid},
-			EndTime: podDeletedTimestamp.Time,
+			EndTime: podDeletedTimestamp.Time.Format(time.RFC3339),
 		}
 		deleteContainersInTerminatedPod(pod.Containers, podDeletedTimestamp.Time)
 	} else {

--- a/pkg/controller/dgraph/models/process.go
+++ b/pkg/controller/dgraph/models/process.go
@@ -40,8 +40,8 @@ type Proc struct {
 	Name      string     `json:"name,omitempty"`
 	Interacts []*Pod     `json:"interacts,omitempty"`
 	Container Container  `json:"container,omitempty"`
-	StartTime time.Time  `json:"startTime,omitempty"`
-	EndTime   time.Time  `json:"endTime,omitempty"`
+	StartTime string     `json:"startTime,omitempty"`
+	EndTime   string     `json:"endTime,omitempty"`
 	Namespace *Namespace `json:"namespace,omitempty"`
 	Type      string     `json:"type,omitempty"`
 }
@@ -53,7 +53,7 @@ func newProc(procXID, procName, containerUID, containerXID string, creationTimeS
 		Type:      "process",
 		Name:      procName,
 		Container: Container{ID: dgraph.ID{UID: containerUID, Xid: containerXID}},
-		StartTime: creationTimeStamp,
+		StartTime: creationTimeStamp.Format(time.RFC3339),
 	}
 	return dgraph.MutateNode(newProc, dgraph.CREATE)
 }

--- a/pkg/controller/dgraph/models/pv.go
+++ b/pkg/controller/dgraph/models/pv.go
@@ -34,12 +34,12 @@ const (
 // PersistentVolume schema in dgraph
 type PersistentVolume struct {
 	dgraph.ID
-	IsPersistentVolume bool      `json:"isPersistentVolume,omitempty"`
-	Name               string    `json:"name,omitempty"`
-	StartTime          time.Time `json:"startTime,omitempty"`
-	EndTime            time.Time `json:"endTime,omitempty"`
-	Type               string    `json:"type,omitempty"`
-	StorageCapacity    float64   `json:"storageCapacity,omitempty"`
+	IsPersistentVolume bool    `json:"isPersistentVolume,omitempty"`
+	Name               string  `json:"name,omitempty"`
+	StartTime          string  `json:"startTime,omitempty"`
+	EndTime            string  `json:"endTime,omitempty"`
+	Type               string  `json:"type,omitempty"`
+	StorageCapacity    float64 `json:"storageCapacity,omitempty"`
 }
 
 func createPersistentVolumeObject(pv api_v1.PersistentVolume) PersistentVolume {
@@ -48,14 +48,14 @@ func createPersistentVolumeObject(pv api_v1.PersistentVolume) PersistentVolume {
 		IsPersistentVolume: true,
 		Type:               "pv",
 		ID:                 dgraph.ID{Xid: pv.Name},
-		StartTime:          pv.GetCreationTimestamp().Time,
+		StartTime:          pv.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	capacity := pv.Spec.Capacity["storage"]
 	newPv.StorageCapacity = utils.ConvertToFloat64GB(&capacity)
 
 	deletionTimestamp := pv.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
-		newPv.EndTime = deletionTimestamp.Time
+		newPv.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newPv
 }

--- a/pkg/controller/dgraph/models/pvc.go
+++ b/pkg/controller/dgraph/models/pvc.go
@@ -36,8 +36,8 @@ type PersistentVolumeClaim struct {
 	dgraph.ID
 	IsPersistentVolumeClaim bool              `json:"isPersistentVolumeClaim,omitempty"`
 	Name                    string            `json:"name,omitempty"`
-	StartTime               time.Time         `json:"startTime,omitempty"`
-	EndTime                 time.Time         `json:"endTime,omitempty"`
+	StartTime               string            `json:"startTime,omitempty"`
+	EndTime                 string            `json:"endTime,omitempty"`
 	Namespace               *Namespace        `json:"namespace,omitempty"`
 	Type                    string            `json:"type,omitempty"`
 	StorageCapacity         float64           `json:"storageCapacity,omitempty"`
@@ -50,7 +50,7 @@ func createPvcObject(pvc api_v1.PersistentVolumeClaim) PersistentVolumeClaim {
 		IsPersistentVolumeClaim: true,
 		Type:                    "pvc",
 		ID:                      dgraph.ID{Xid: pvc.Namespace + ":" + pvc.Name},
-		StartTime:               pvc.GetCreationTimestamp().Time,
+		StartTime:               pvc.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	capacity := pvc.Status.Capacity["storage"]
 	newPvc.StorageCapacity = utils.ConvertToFloat64GB(&capacity)
@@ -67,7 +67,7 @@ func createPvcObject(pvc api_v1.PersistentVolumeClaim) PersistentVolumeClaim {
 	}
 	deletionTimestamp := pvc.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
-		newPvc.EndTime = deletionTimestamp.Time
+		newPvc.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newPvc
 }

--- a/pkg/controller/dgraph/models/replicaset.go
+++ b/pkg/controller/dgraph/models/replicaset.go
@@ -35,8 +35,8 @@ type Replicaset struct {
 	dgraph.ID
 	IsReplicaset bool        `json:"isReplicaset,omitempty"`
 	Name         string      `json:"name,omitempty"`
-	StartTime    time.Time   `json:"startTime,omitempty"`
-	EndTime      time.Time   `json:"endTime,omitempty"`
+	StartTime    string      `json:"startTime,omitempty"`
+	EndTime      string      `json:"endTime,omitempty"`
 	Namespace    *Namespace  `json:"namespace,omitempty"`
 	Deployment   *Deployment `json:"deployment,omitempty"`
 	Pods         []*Pod      `json:"pods,omitempty"`
@@ -49,7 +49,7 @@ func createReplicasetObject(replicaset ext_v1beta1.ReplicaSet) Replicaset {
 		IsReplicaset: true,
 		Type:         "replicaset",
 		ID:           dgraph.ID{Xid: replicaset.Namespace + ":" + replicaset.Name},
-		StartTime:    replicaset.GetCreationTimestamp().Time,
+		StartTime:    replicaset.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	namespaceUID := CreateOrGetNamespaceByID(replicaset.Namespace)
 	if namespaceUID != "" {
@@ -57,7 +57,7 @@ func createReplicasetObject(replicaset ext_v1beta1.ReplicaSet) Replicaset {
 	}
 	replicasetDeletionTimestamp := replicaset.GetDeletionTimestamp()
 	if !replicasetDeletionTimestamp.IsZero() {
-		newReplicaset.EndTime = replicasetDeletionTimestamp.Time
+		newReplicaset.EndTime = replicasetDeletionTimestamp.Time.Format(time.RFC3339)
 	}
 	setReplicasetOwners(&newReplicaset, replicaset)
 	return newReplicaset

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -37,8 +37,8 @@ type Service struct {
 	dgraph.ID
 	IsService bool       `json:"isService,omitempty"`
 	Name      string     `json:"name,omitempty"`
-	StartTime time.Time  `json:"startTime,omitempty"`
-	EndTime   time.Time  `json:"endTime,omitempty"`
+	StartTime string     `json:"startTime,omitempty"`
+	EndTime   string     `json:"endTime,omitempty"`
 	Pod       []*Pod     `json:"pod,omitempty"`
 	Interacts []*Service `json:"interacts,omitempty"`
 	Namespace *Namespace `json:"namespace,omitempty"`
@@ -51,7 +51,7 @@ func newService(svc api_v1.Service) (*api.Assigned, error) {
 		IsService: true,
 		Type:      "service",
 		ID:        dgraph.ID{Xid: svc.Namespace + ":" + svc.Name},
-		StartTime: svc.GetCreationTimestamp().Time,
+		StartTime: svc.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	namespaceUID := CreateOrGetNamespaceByID(svc.Namespace)
 	if namespaceUID != "" {
@@ -78,7 +78,7 @@ func StoreService(service api_v1.Service) error {
 	if !svcDeletionTimestamp.IsZero() {
 		updatedService := Service{
 			ID:      dgraph.ID{Xid: xid, UID: uid},
-			EndTime: svcDeletionTimestamp.Time,
+			EndTime: svcDeletionTimestamp.Time.Format(time.RFC3339),
 		}
 		_, err := dgraph.MutateNode(updatedService, dgraph.UPDATE)
 		return err

--- a/pkg/controller/dgraph/models/statefulset.go
+++ b/pkg/controller/dgraph/models/statefulset.go
@@ -35,8 +35,8 @@ type Statefulset struct {
 	dgraph.ID
 	IsStatefulset bool       `json:"isStatefulset,omitempty"`
 	Name          string     `json:"name,omitempty"`
-	StartTime     time.Time  `json:"startTime,omitempty"`
-	EndTime       time.Time  `json:"endTime,omitempty"`
+	StartTime     string     `json:"startTime,omitempty"`
+	EndTime       string     `json:"endTime,omitempty"`
 	Namespace     *Namespace `json:"namespace,omitempty"`
 	Pods          []*Pod     `json:"pods,omitempty"`
 	Type          string     `json:"type,omitempty"`
@@ -48,7 +48,7 @@ func createStatefulsetObject(statefulset apps_v1beta1.StatefulSet) Statefulset {
 		IsStatefulset: true,
 		Type:          "statefulset",
 		ID:            dgraph.ID{Xid: statefulset.Namespace + ":" + statefulset.Name},
-		StartTime:     statefulset.GetCreationTimestamp().Time,
+		StartTime:     statefulset.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 	namespaceUID := CreateOrGetNamespaceByID(statefulset.Namespace)
 	if namespaceUID != "" {
@@ -56,7 +56,7 @@ func createStatefulsetObject(statefulset apps_v1beta1.StatefulSet) Statefulset {
 	}
 	statefulsetDeletionTimestamp := statefulset.GetDeletionTimestamp()
 	if !statefulsetDeletionTimestamp.IsZero() {
-		newStatefulset.EndTime = statefulsetDeletionTimestamp.Time
+		newStatefulset.EndTime = statefulsetDeletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newStatefulset
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
All timestamps are stored as '0' in dgraph. With this PR correct timestamps will be persisted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #93 
