### PR TITLE
Compute and add api endpoints for interaction-Graph nodes and edges

### DIFF
--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/vmware/purser-dev/pkg/controller/discovery/graph"
 	"github.com/vmware/purser/pkg/controller/dgraph/models"
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
 	"github.com/vmware/purser/pkg/controller/discovery/generator"

--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -412,12 +412,12 @@ func GetPVCMetrics(w http.ResponseWriter, r *http.Request) {
 
 // GetPodDiscoveryNodes listens on /discovery/pod/nodes endpoint
 func GetPodDiscoveryNodes(w http.ResponseWriter, r *http.Request) {
-	var pod []models.Pod
+	var pods []models.Pod
 	var err error
 
 	addHeaders(&w, r)
-	pod, err = query.RetrievePodsInteractionsForAllLivePodsWithCount()
-	generator.GeneratePodNodesAndEdges(pod)
+	pods, err = query.RetrievePodsInteractionsForAllLivePodsWithCount()
+	generator.GeneratePodNodesAndEdges(pods)
 	if err != nil {
 		logrus.Errorf("Unable to get response: (%v)", err)
 	}

--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -21,7 +21,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser-dev/pkg/controller/discovery/graph"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
+	"github.com/vmware/purser/pkg/controller/discovery/generator"
 	"io"
 	"net/http"
 )
@@ -406,6 +409,37 @@ func GetPVCMetrics(w http.ResponseWriter, r *http.Request) {
 		logrus.Errorf("wrong type of query for PVC, no name is given")
 	}
 	encodeAndWrite(w, jsonData)
+}
+
+// GetPodDiscoveryNodes listens on /discovery/pod/nodes endpoint
+func GetPodDiscoveryNodes(w http.ResponseWriter, r *http.Request) {
+	var pod []models.Pod
+	var err error
+
+	addHeaders(&w, r)
+	pod, err = query.RetrievePodsInteractionsForAllLivePodsWithCount()
+	generator.GeneratePodNodesAndEdges(pod)
+	if err != nil {
+		logrus.Errorf("Unable to get response: (%v)", err)
+	}
+	err = json.NewEncoder(w).Encode(generator.GetGraphNodes())
+	if err != nil {
+		logrus.Errorf("Unable to encode to json: (%v)", err)
+	}
+}
+
+// GetPodDiscoveryEdges listens on /discovery/pod/edges endpoint
+func GetPodDiscoveryEdges(w http.ResponseWriter, r *http.Request) {
+	var err error
+	addHeaders(&w, r)
+	if err != nil {
+		logrus.Errorf("Unable to get response: (%v)", err)
+	}
+
+	err = json.NewEncoder(w).Encode(generator.GetGraphEdges())
+	if err != nil {
+		logrus.Errorf("Unable to encode to json: (%v)", err)
+	}
 }
 
 func addHeaders(w *http.ResponseWriter, r *http.Request) {

--- a/cmd/controller/api/routes.go
+++ b/cmd/controller/api/routes.go
@@ -195,4 +195,10 @@ var routes = Routes{
 		"/metrics/pvc",
 		GetPVCMetrics,
 	},
+	Route{
+		"GetPodDiscoveryNodes",
+		"GET",
+		"/nodes",
+		GetPodDiscoveryNodes,
+	},
 }

--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -57,7 +57,7 @@ func newContainer(container api_v1.Container, podUID, namespaceUID string, pod a
 	limits := container.Resources.Limits
 	c := &Container{
 		ID:            dgraph.ID{Xid: containerXid},
-		Name:          container.Name,
+		Name:          "container-" + container.Name,
 		IsContainer:   true,
 		Type:          "container",
 		StartTime:     pod.GetCreationTimestamp().Time.Format(time.RFC3339),

--- a/pkg/controller/dgraph/models/daemonset.go
+++ b/pkg/controller/dgraph/models/daemonset.go
@@ -44,7 +44,7 @@ type Daemonset struct {
 
 func createDaemonsetObject(daemonset ext_v1beta1.DaemonSet) Daemonset {
 	newDaemonset := Daemonset{
-		Name:        daemonset.Name,
+		Name:        "daemonset-" + daemonset.Name,
 		IsDaemonset: true,
 		Type:        "daemonset",
 		ID:          dgraph.ID{Xid: daemonset.Namespace + ":" + daemonset.Name},

--- a/pkg/controller/dgraph/models/deployment.go
+++ b/pkg/controller/dgraph/models/deployment.go
@@ -38,13 +38,13 @@ type Deployment struct {
 	StartTime    string     `json:"startTime,omitempty"`
 	EndTime      string     `json:"endTime,omitempty"`
 	Namespace    *Namespace `json:"namespace,omitempty"`
-	Pods         []*Pod     `json:"pods,omitempty"`
+	Pods         []*Pod     `json:"pod,omitempty"`
 	Type         string     `json:"type,omitempty"`
 }
 
 func createDeploymentObject(deployment apps_v1beta1.Deployment) Deployment {
 	newDeployment := Deployment{
-		Name:         deployment.Name,
+		Name:         "deployment-" + deployment.Name,
 		IsDeployment: true,
 		Type:         "deployment",
 		ID:           dgraph.ID{Xid: deployment.Namespace + ":" + deployment.Name},

--- a/pkg/controller/dgraph/models/namespace.go
+++ b/pkg/controller/dgraph/models/namespace.go
@@ -45,7 +45,7 @@ type Namespace struct {
 func newNamespace(namespace api_v1.Namespace) Namespace {
 	ns := Namespace{
 		ID:          dgraph.ID{Xid: namespace.Name},
-		Name:        namespace.Name,
+		Name:        "namespace-" + namespace.Name,
 		IsNamespace: true,
 		Type:        "namespace",
 		StartTime:   namespace.GetCreationTimestamp().Time.Format(time.RFC3339),

--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -48,7 +48,7 @@ type Node struct {
 
 func createNodeObject(node api_v1.Node) Node {
 	newNode := Node{
-		Name:           node.Name,
+		Name:           "node-" + node.Name,
 		IsNode:         true,
 		Type:           "node",
 		ID:             dgraph.ID{Xid: node.Name},

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -72,7 +72,7 @@ type Metrics struct {
 // newPod creates a new node for the pod in the Dgraph
 func newPod(k8sPod api_v1.Pod) (*api.Assigned, error) {
 	pod := Pod{
-		Name:      k8sPod.Name,
+		Name:      "pod-" + k8sPod.Name,
 		IsPod:     true,
 		Type:      "pod",
 		ID:        dgraph.ID{Xid: k8sPod.Namespace + ":" + k8sPod.Name},

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -58,6 +58,7 @@ type Pod struct {
 	MemoryLimit    float64                  `json:"memoryLimit,omitempty"`
 	StorageRequest float64                  `json:"storageRequest,omitempty"`
 	Type           string                   `json:"type,omitempty"`
+	Cid            []Service                `json:"cid,omitempty"`
 }
 
 // Metrics ...

--- a/pkg/controller/dgraph/models/process.go
+++ b/pkg/controller/dgraph/models/process.go
@@ -51,7 +51,7 @@ func newProc(procXID, procName, containerUID, containerXID string, creationTimeS
 		ID:        dgraph.ID{Xid: procXID},
 		IsProc:    true,
 		Type:      "process",
-		Name:      procName,
+		Name:      "process-" + procName,
 		Container: Container{ID: dgraph.ID{UID: containerUID, Xid: containerXID}},
 		StartTime: creationTimeStamp.Format(time.RFC3339),
 	}

--- a/pkg/controller/dgraph/models/pv.go
+++ b/pkg/controller/dgraph/models/pv.go
@@ -44,7 +44,7 @@ type PersistentVolume struct {
 
 func createPersistentVolumeObject(pv api_v1.PersistentVolume) PersistentVolume {
 	newPv := PersistentVolume{
-		Name:               pv.Name,
+		Name:               "pv-" + pv.Name,
 		IsPersistentVolume: true,
 		Type:               "pv",
 		ID:                 dgraph.ID{Xid: pv.Name},

--- a/pkg/controller/dgraph/models/pvc.go
+++ b/pkg/controller/dgraph/models/pvc.go
@@ -46,7 +46,7 @@ type PersistentVolumeClaim struct {
 
 func createPvcObject(pvc api_v1.PersistentVolumeClaim) PersistentVolumeClaim {
 	newPvc := PersistentVolumeClaim{
-		Name:                    pvc.Name,
+		Name:                    "pvc-" + pvc.Name,
 		IsPersistentVolumeClaim: true,
 		Type:                    "pvc",
 		ID:                      dgraph.ID{Xid: pvc.Namespace + ":" + pvc.Name},

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -20,6 +20,7 @@ package query
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
 )
 
 // RetrievePodsInteractions returns inbound and outbound interactions of a pod
@@ -119,4 +120,30 @@ func RetrievePodMetrics(name string) JSONDataWrapper {
 		}
 	}`
 	return getJSONDataFromQuery(query)
+}
+
+// RetrievePodsInteractionsForAllPodsOrphanedTrue returns all pods in the dgraph
+func RetrievePodsInteractionsForAllLivePodsWithCount() ([]models.Pod, error) {
+	q := `query {
+		pods(func: has(isPod)) @filter((NOT has(endTime))) {
+			name
+			pod {
+				name
+				count
+			}
+			cid: ~pod @filter(has(isService)) {
+				name
+			}
+		}
+	}`
+
+	type root struct {
+		Pods []models.Pod `json:"pods"`
+	}
+	newRoot := root{}
+	err := dgraph.ExecuteQuery(q, &newRoot)
+	if err != nil {
+		return nil, err
+	}
+	return newRoot.Pods, nil
 }

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -122,7 +122,7 @@ func RetrievePodMetrics(name string) JSONDataWrapper {
 	return getJSONDataFromQuery(query)
 }
 
-// RetrievePodsInteractionsForAllPodsOrphanedTrue returns all pods in the dgraph
+// RetrievePodsInteractionsForAllLivePodsWithCount returns all pods in the dgraph
 func RetrievePodsInteractionsForAllLivePodsWithCount() ([]models.Pod, error) {
 	q := `query {
 		pods(func: has(isPod)) @filter((NOT has(endTime))) {

--- a/pkg/controller/dgraph/models/replicaset.go
+++ b/pkg/controller/dgraph/models/replicaset.go
@@ -39,13 +39,13 @@ type Replicaset struct {
 	EndTime      string      `json:"endTime,omitempty"`
 	Namespace    *Namespace  `json:"namespace,omitempty"`
 	Deployment   *Deployment `json:"deployment,omitempty"`
-	Pods         []*Pod      `json:"pods,omitempty"`
+	Pods         []*Pod      `json:"pod,omitempty"`
 	Type         string      `json:"type,omitempty"`
 }
 
 func createReplicasetObject(replicaset ext_v1beta1.ReplicaSet) Replicaset {
 	newReplicaset := Replicaset{
-		Name:         replicaset.Name,
+		Name:         "replicaset-" + replicaset.Name,
 		IsReplicaset: true,
 		Type:         "replicaset",
 		ID:           dgraph.ID{Xid: replicaset.Namespace + ":" + replicaset.Name},

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -47,7 +47,7 @@ type Service struct {
 
 func newService(svc api_v1.Service) (*api.Assigned, error) {
 	newService := Service{
-		Name:      "sevice-" + svc.Name,
+		Name:      "service-" + svc.Name,
 		IsService: true,
 		Type:      "service",
 		ID:        dgraph.ID{Xid: svc.Namespace + ":" + svc.Name},

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -47,7 +47,7 @@ type Service struct {
 
 func newService(svc api_v1.Service) (*api.Assigned, error) {
 	newService := Service{
-		Name:      svc.Name,
+		Name:      "sevice-" + svc.Name,
 		IsService: true,
 		Type:      "service",
 		ID:        dgraph.ID{Xid: svc.Namespace + ":" + svc.Name},
@@ -121,7 +121,7 @@ func StorePodServiceEdges(svcXID string, podsXIDsInService []string) error {
 // RetrieveAllServices returns all pods in the dgraph
 func RetrieveAllServices() ([]Service, error) {
 	const q = `query {
-		services(func: has(isService)) {
+		service(func: has(isService)) {
 			name
 			interacts @facets {
 				name
@@ -133,7 +133,7 @@ func RetrieveAllServices() ([]Service, error) {
 	}`
 
 	type root struct {
-		Services []Service `json:"services"`
+		Services []Service `json:"service"`
 	}
 	newRoot := root{}
 	err := dgraph.ExecuteQuery(q, &newRoot)

--- a/pkg/controller/dgraph/models/statefulset.go
+++ b/pkg/controller/dgraph/models/statefulset.go
@@ -20,9 +20,9 @@ package models
 import (
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	apps_v1beta1 "k8s.io/api/apps/v1beta1"
-	"log"
 )
 
 // Dgraph Model Constants
@@ -44,7 +44,7 @@ type Statefulset struct {
 
 func createStatefulsetObject(statefulset apps_v1beta1.StatefulSet) Statefulset {
 	newStatefulset := Statefulset{
-		Name:          statefulset.Name,
+		Name:          "statefulset-" + statefulset.Name,
 		IsStatefulset: true,
 		Type:          "statefulset",
 		ID:            dgraph.ID{Xid: statefulset.Namespace + ":" + statefulset.Name},

--- a/pkg/controller/discovery/generator/graph.go
+++ b/pkg/controller/discovery/generator/graph.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generator
+
+import (
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+	"strconv"
+)
+
+// Node represents each node in the graph
+// ID: unique id of pod
+// Label: pod name
+// Title: string "pods"
+// Value: number of times pod has communicated with others
+// Group: Connected component number, used for coloring different components in different colors
+// CID: list of all services the pod belongs to.
+type Node struct {
+	ID    int      `json:"id"`
+	Label string   `json:"label"`
+	Title string   `json:"title"`
+	Value int      `json:"value"`
+	Group int      `json:"group"`
+	Cid   []string `json:"cid"`
+}
+
+// Edge represents each edge in the graph
+// From: unique id of source pod
+// TO: unique id of destination pod
+// Title: string containing number of times these two pods communicated
+type Edge struct {
+	From  int    `json:"from"`
+	To    int    `json:"to"`
+	Title string `json:"title"`
+}
+
+var (
+	uniqueID = 0
+	nodes    *[]Node
+	edges    *[]Edge
+)
+
+// GetGraphNodes returns graph-nodes for pod interactions
+func GetGraphNodes() []Node {
+	return *nodes
+}
+
+// GetGraphEdges returns graph-edges for pod interactions
+func GetGraphEdges() []Edge {
+	return *edges
+}
+
+// GeneratePodNodesAndEdges ...
+func GeneratePodNodesAndEdges(pods []models.Pod) {
+	uniqueID = 0
+	uniqueIDs, numConnections, inboundAndOutboundConnections := getPodUniqueIDsAndNumConnections(pods)
+	podNodes := createPodNodes(pods, uniqueIDs, numConnections, inboundAndOutboundConnections)
+	podEdges := createPodEdges(pods, uniqueIDs)
+	setGraphNodes(podNodes)
+	setGraphEdges(podEdges)
+}
+
+func getPodUniqueIDsAndNumConnections(pods []models.Pod) (map[string]int, map[string]int, map[string]int) {
+	uniqueIDs := make(map[string]int)
+	numConnections := make(map[string]int)
+	inboundAndOutboundConnections := make(map[string]int)
+	for _, pod := range pods {
+		setPodUniqueIDsAndNumConnections(pod, uniqueIDs, numConnections, inboundAndOutboundConnections)
+	}
+	return uniqueIDs, numConnections, inboundAndOutboundConnections
+}
+
+func setPodUniqueIDsAndNumConnections(pod models.Pod, uniqueIDs, numConnections, inboundAndOutboundConnections map[string]int) {
+	if _, isPresent := uniqueIDs[pod.Name]; !isPresent {
+		uniqueID++
+		uniqueIDs[pod.Name] = uniqueID
+		numConnections[pod.Name] = 0
+		for _, dstPod := range pod.Pods {
+			numConnections[pod.Name] += int(dstPod.Count)
+			inboundAndOutboundConnections[pod.Name] += int(dstPod.Count)
+			inboundAndOutboundConnections[dstPod.Name] += int(dstPod.Count)
+		}
+	}
+}
+
+func createPodNodes(pods []models.Pod, uniqueIDs, numConnections, inboundAndOutboundConnections map[string]int) []Node {
+	nodes := []Node{}
+	duplicateChecker := make(map[string]bool)
+	for _, pod := range pods {
+		if _, isNotOrphan := inboundAndOutboundConnections[pod.Name]; isNotOrphan {
+			if _, isPresent := duplicateChecker[pod.Name]; !isPresent {
+				duplicateChecker[pod.Name] = true
+				svcCid := []string{}
+				for _, svc := range pod.Cid {
+					svcCid = append(svcCid, svc.Name)
+				}
+				newPodNode := createPodNode(pod.Name, uniqueIDs[pod.Name], numConnections[pod.Name], svcCid)
+				nodes = append(nodes, newPodNode)
+			}
+		}
+	}
+	return nodes
+}
+
+func createPodEdges(pods []models.Pod, uniqueIDs map[string]int) []Edge {
+	edges := []Edge{}
+	for _, pod := range pods {
+		srcID := uniqueIDs[pod.Name]
+		for _, dstPod := range pod.Pods {
+			destID := uniqueIDs[dstPod.Name]
+			edges = append(edges, createPodEdge(srcID, destID, int(dstPod.Count)))
+		}
+	}
+	return edges
+}
+
+func createPodNode(podName string, podID int, podConnections int, cid []string) Node {
+	return Node{
+		ID:    podID,
+		Label: podName,
+		Title: "pods",
+		Value: podConnections,
+		Group: 1,
+		Cid:   cid,
+	}
+}
+
+func createPodEdge(fromID int, toID int, count int) Edge {
+	return Edge{
+		From:  fromID,
+		To:    toID,
+		Title: strconv.Itoa(count) + " times communicated",
+	}
+}
+
+func setGraphNodes(podNodes []Node) {
+	nodes = &podNodes
+}
+
+func setGraphEdges(podEdges []Edge) {
+	edges = &podEdges
+}

--- a/pkg/controller/discovery/generator/graph.go
+++ b/pkg/controller/discovery/generator/graph.go
@@ -49,7 +49,7 @@ type Edge struct {
 }
 
 var (
-	uniqueID = 0
+	uniqueID int
 	nodes    *[]Node
 	edges    *[]Edge
 )
@@ -134,7 +134,7 @@ func createPodNode(podName string, podID int, podConnections int, cid []string) 
 		Label: podName,
 		Title: "pods",
 		Value: podConnections,
-		Group: 1,
+		Group: 1, // needed for UI, colors different group differently(not needed for our use case)
 		Cid:   cid,
 	}
 }

--- a/pkg/controller/discovery/linker/podlinks.go
+++ b/pkg/controller/discovery/linker/podlinks.go
@@ -60,6 +60,7 @@ func PopulatePodIPTable(pods *corev1.PodList) {
 
 // GenerateAndStorePodInteractions generates source to destination Pod mapping and stores it in Dgraph.
 func GenerateAndStorePodInteractions() {
+	log.Info("Storing Pod Interactions ....")
 	for srcPodName, communication := range podToPodTable {
 		dstPods := []string{}
 		counts := []float64{}
@@ -72,6 +73,7 @@ func GenerateAndStorePodInteractions() {
 			log.Errorf("failed to store pod interaction in Dgraph %v", err)
 		}
 	}
+	log.Info("Finished storing pod interactions.")
 }
 
 // PopulateMappingTables updates PodToPodTable
@@ -91,6 +93,7 @@ func PopulateMappingTables(tcpDump []string, pod corev1.Pod, process Process, co
 
 func updatePodInteractions(srcName, dstName string, interactions *InteractionsWrapper) {
 	if dstName != "" && srcName != "" {
+		log.Debugf("pod interactions srcName: (%s), dstName: (%s)", srcName, dstName)
 		if _, ok := interactions.PodInteractions[srcName]; !ok {
 			interactions.PodInteractions[srcName] = make(map[string]float64)
 		}

--- a/pkg/controller/discovery/linker/processlinks.go
+++ b/pkg/controller/discovery/linker/processlinks.go
@@ -40,12 +40,12 @@ func StoreProcessInteractions(containerProcessInteraction map[string][]string, p
 
 			err := models.StoreProcess(procXID, containerXID, podsXIDs, creationTime)
 			if err != nil {
-				log.Errorf("failed to store process details: %s", procXID)
+				log.Errorf("failed to store process details: %s, err: (%v)", procXID, err)
 			}
 		}
 		err := models.StoreContainerProcessEdge(containerXID, procsXIDs)
 		if err != nil {
-			log.Errorf("failed to store edge from container: %s to procs", containerXID)
+			log.Errorf("failed to store edge from container: %s to procs, err: (%v)", containerXID, err)
 		}
 	}
 }

--- a/pkg/controller/discovery/processor/cluster.go
+++ b/pkg/controller/discovery/processor/cluster.go
@@ -27,7 +27,7 @@ import (
 
 // RetrievePodList returns list of pods in the given namespace.
 func RetrievePodList(client *kubernetes.Clientset, options metav1.ListOptions) *corev1.PodList {
-	pods, err := client.CoreV1().Pods("").List(options)
+	pods, err := client.CoreV1().Pods(metav1.NamespaceAll).List(options)
 	if err != nil {
 		log.Errorf("failed to retrieve pods: %v", err)
 	}
@@ -36,7 +36,7 @@ func RetrievePodList(client *kubernetes.Clientset, options metav1.ListOptions) *
 
 // RetrieveServiceList returns list of services in the given namespace.
 func RetrieveServiceList(client *kubernetes.Clientset, options metav1.ListOptions) *corev1.ServiceList {
-	services, err := client.CoreV1().Services("").List(options)
+	services, err := client.CoreV1().Services(metav1.NamespaceAll).List(options)
 	if err != nil {
 		log.Errorf("failed to retrieve services: %v", err)
 	}

--- a/pkg/controller/discovery/processor/container.go
+++ b/pkg/controller/discovery/processor/container.go
@@ -65,7 +65,10 @@ func getPIDList(conf controller.Config, pod corev1.Pod, containerName string) ([
 		}
 	}
 	// ignore first line i.e, PID CMD headers
-	return pidList[1:], cmdList[1:]
+	if len(pidList) >= 1 {
+		return pidList[1:], cmdList[1:]
+	}
+	return pidList, cmdList
 }
 
 func getProcessDump(conf controller.Config, pod corev1.Pod, containerName string, process linker.Process, interactions *linker.InteractionsWrapper) {

--- a/pkg/controller/discovery/processor/pod.go
+++ b/pkg/controller/discovery/processor/pod.go
@@ -50,7 +50,7 @@ func processPodDetails(conf controller.Config, pods *corev1.PodList) {
 	wg.Add(podsCount)
 	{
 		for index, pod := range pods.Items {
-			log.Debugf("Processing Pod (%d/%d) ... ", index+1, podsCount)
+			log.Debugf("Processing Pod: (%s), (%d/%d) ... ", pod.Name, index+1, podsCount)
 
 			go func(pod corev1.Pod, index int) {
 				defer wg.Done()
@@ -60,7 +60,7 @@ func processPodDetails(conf controller.Config, pods *corev1.PodList) {
 				linker.UpdatePodToPodTable(interactions.PodInteractions)
 				linker.StoreProcessInteractions(interactions.ContainerProcessInteraction, interactions.ProcessToPodInteraction,
 					pod.GetCreationTimestamp().Time)
-				log.Debugf("Finished processing Pod (%d/%d)", index+1, podsCount)
+				log.Debugf("Finished processing Pod: (%s), (%d/%d)", pod.Name, index+1, podsCount)
 			}(pod, index)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Compute and add api endpoints for Graph nodes and edges
2. few fixes and name stored in dgraph is changed to type-name. This will help in UI to form hierarchy based on names.

**Which issue(s) this PR fixes**:
Fixes a task in #46 
