### PR TITLE
feat(#91): adds listener for CRDs and persist CRDs in Dgraph.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,244 +2,337 @@
 
 
 [[projects]]
+  digest = "1:d1665c44bd5db19aaee18d1b6233c99b0b9a986e8bccb24ef54747547a48027f"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c739832d67eb1e9cc478a19cc1a1ccd78df0397bf8a32978b759152e205f644b"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = "UT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:519fe564f9b2c64c0861e98ee185d9b8b6179f64ceae072d9f3b85698dc9c3f4"
   name = "github.com/dgraph-io/dgo"
   packages = [
     ".",
     "protos/api",
-    "y"
+    "y",
   ]
+  pruneopts = "UT"
   revision = "92bc132b4838ddff5b6c2387cefb87b84c1bbc56"
 
 [[projects]]
   branch = "master"
+  digest = "1:ecdc8e0fe3bc7d549af1c9c36acf3820523b707d6c071b6d0c3860882c6f7b42"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy"
+    "spdy",
   ]
+  pruneopts = "UT"
   revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
 
 [[projects]]
+  digest = "1:899234af23e5793c34e06fd397f86ba33af5307b959b6a7afd19b63db065a9d7"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = "UT"
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
 
 [[projects]]
+  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:953a2628e4c5c72856b53f5470ed5e071c55eccf943d798d42908102af2a610f"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
   version = "v0.17.1"
 
 [[projects]]
+  digest = "1:81210e0af657a0fb3638932ec68e645236bceefa4c839823db0c4d918f080895"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
   version = "v0.17.1"
 
 [[projects]]
+  digest = "1:394fed5c0425fe01da3a34078adaa1682e4deaea6e5d232dde25c4034004c151"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
   version = "v0.17.1"
 
 [[projects]]
+  digest = "1:32f3d2e7f343de7263c550d696fb8a64d3c49d8df16b1ddfc8e80e1e4b3233ce"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
   version = "v0.17.1"
 
 [[projects]]
+  digest = "1:34e709f36fd4f868fb00dbaf8a6cab4c1ae685832d392874ba9d7c5dec2429d1"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "UT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
+  digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "UT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:664d37ea261f0fc73dd17f4a1f5f46d01fbb0b0d75f6375af064824424109b7d"
+  name = "github.com/gorilla/handlers"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7e0847f9db758cdebd26c149d0ae9d5d0b9c98ce"
+  version = "v1.4.0"
+
+[[projects]]
+  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
+
+[[projects]]
   branch = "master"
+  digest = "1:86c1210529e69d69860f2bb3ee9ccce0b595aa3f9165e7dd1388e5c612915888"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "UT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
+  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "UT"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0778dc7fce1b4669a8bfa7ae506ec1f595b6ab0f8989c1c0d22a8ca1144e9972"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:8eb1de8112c9924d59bf1d3e5c26f5eaa2bfc2a5fcbb92dc1c2e4546d695f277"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "UT"
   revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
   version = "v0.3.6"
 
 [[projects]]
+  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
+  digest = "1:190ff84d9b2ed6589088f178cba8edb4b8ecb334df4572421fb016be1ac20463"
   name = "github.com/juju/ratelimit"
   packages = ["."]
+  pruneopts = "UT"
   revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "UT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "UT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:0e7775ebbcf00d8dd28ac663614af924411c868dca3d5aa762af0fae3808d852"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:ed615c5430ecabbb0fb7629a182da65ecee6523900ac1ac932520860878ffcad"
   name = "github.com/robfig/cron"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b41be1df696709bb6395fe435af20370037c0b4c"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
 
 [[projects]]
   branch = "master"
+  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -248,20 +341,24 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "9b4f9f5ad5197c79fd623a3638e70d8b26cef344"
 
 [[projects]]
   branch = "master"
+  digest = "1:899c684138eb2844811b7f97e264d3c65d533dbedc59549fa58fc2bf316f83a1"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "44b849a8bc13eb42e95e6c6c5e360481b73ec710"
 
 [[projects]]
+  digest = "1:0c56024909189aee3364b7f21a95a27459f718aa7c199a5c111c36cfffd9eaef"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -278,18 +375,22 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:56b0bca90b7e5d1facf5fbdacba23e4e0ce069d25381b8e2f70ef1e7ebfb9c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
   revision = "94acd270e44e65579b9ee3cdab25034d33fed608"
 
 [[projects]]
+  digest = "1:c3ad9841823db6da420a5625b367913b4ff54bbe60e8e3c98bd20e243e62e2d2"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -317,24 +418,30 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = "UT"
   revision = "2e463a05d100327ca47ac218281906921038fd95"
   version = "v1.16.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:ed72a891abbac385714a6929856161591ccf6d0281de47756ac777563e944e14"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -364,24 +471,28 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "UT"
   revision = "af4bc157c3a209798fc897f6d4aaaaeb6c2e0d6a"
   version = "kubernetes-1.9.0"
 
 [[projects]]
+  digest = "1:5082b101fc5970156d7a6df14df8064cdd5b60fbdaef9c896d6be26a698b5682"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
     "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
-    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
+  pruneopts = "UT"
   revision = "98ecf7bbd60f9f11a72000e4f05203f542136219"
   version = "kubernetes-1.9.0"
 
 [[projects]]
+  digest = "1:45c958c7f4673ab10167688e85db83a826951cfe24df389160a82039ed138843"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -425,12 +536,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "UT"
   revision = "180eddb345a5be3a157cea1c624700ad5bd27b8f"
   version = "kubernetes-1.9.0"
 
 [[projects]]
+  digest = "1:33b5a64ab86a11813d53c3b73e4136d047e31845adc90ae5bde9fa9b7af33f3c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -485,20 +598,53 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "UT"
   revision = "78700dec6369ba22221b72770783300f143df150"
   version = "v6.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2932fadf06c2947e04e1f95fc7d4de2e6d32ebd4197a824a5b1e2a0e042c8e14"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
+  pruneopts = "UT"
   revision = "96e8bb74ecdddb93a882ef95d2b8ec49e93168ee"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39f749d1ab19f3523545b0215c68694423d4c88a7c47993f2e3861384a5d925f"
+  input-imports = [
+    "github.com/Sirupsen/logrus",
+    "github.com/dgraph-io/dgo",
+    "github.com/dgraph-io/dgo/protos/api",
+    "github.com/gorilla/handlers",
+    "github.com/gorilla/mux",
+    "github.com/robfig/cron",
+    "google.golang.org/grpc",
+    "k8s.io/api/apps/v1beta1",
+    "k8s.io/api/batch/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/remotecommand",
+    "k8s.io/client-go/util/workqueue",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cluster/artifacts/example-group.yaml
+++ b/cluster/artifacts/example-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: vmware.purser.com/v1
+kind: Group
+metadata:
+ name: example-group
+spec:
+ name: example-group
+ labels:
+   app: sample-app

--- a/cluster/artifacts/example-subscriber.yaml
+++ b/cluster/artifacts/example-subscriber.yaml
@@ -1,4 +1,4 @@
-apiVersion: purser.subscriber/v1
+apiVersion: vmware.purser.com/v1
 kind: Subscriber
 metadata:
   name: example-subscriber

--- a/cluster/artifacts/example-subscriber.yaml
+++ b/cluster/artifacts/example-subscriber.yaml
@@ -1,0 +1,11 @@
+apiVersion: purser.subscriber/v1
+kind: Subscriber
+metadata:
+  name: example-subscriber
+spec:
+  name: example-subscriber
+  cspOrgId: <optional>
+  cluster: <your-cluster-name>
+  authType: access-token
+  authToken: <your-token>
+  url: <your-webhook-url>

--- a/cluster/artifacts/purser-group-crd.yaml
+++ b/cluster/artifacts/purser-group-crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: groups.vmware.kuber
+  name: groups.vmware.purser.com
 spec:
-  group: vmware.kuber
+  group: vmware.purser.com
   names:
     kind: Group
     listKind: GroupList

--- a/cluster/artifacts/purser-subscriber-crd.yaml
+++ b/cluster/artifacts/purser-subscriber-crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscribers.vmware.purser.com
+spec:
+  group: vmware.purser.com
+  names:
+    kind: Subscriber
+    listKind: SubscriberList
+    plural: subscribers
+    singular: subscriber
+  scope: Namespaced
+  version: v1
+status:
+  acceptedNames:
+    kind: Subscriber
+    listKind: SubscriberList
+    plural: subscribers
+    singular: subscriber

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -57,6 +57,8 @@ func Setup(conf *controller.Config) {
 		Job:                   true,
 		Service:               true,
 		Namespace:             true,
+		Group:                 true,
+		Subscriber:            true,
 	}
 	conf.RingBuffer = &buffering.RingBuffer{Size: buffering.BufferSize, Mutex: &sync.Mutex{}}
 	clientset, clusterConfig := client.GetAPIExtensionClient(*kubeconfig)

--- a/pkg/apis/groups/v1/types.go
+++ b/pkg/apis/groups/v1/types.go
@@ -26,7 +26,7 @@ import (
 // CRD Group attributes
 const (
 	CRDPlural   string = "groups"
-	CRDGroup    string = "vmware.kuber"
+	CRDGroup    string = "purser"
 	CRDVersion  string = "v1"
 	FullCRDName string = CRDPlural + "." + CRDGroup
 )

--- a/pkg/apis/groups/v1/types.go
+++ b/pkg/apis/groups/v1/types.go
@@ -26,7 +26,7 @@ import (
 // CRD Group attributes
 const (
 	CRDPlural   string = "groups"
-	CRDGroup    string = "vmware.purser"
+	CRDGroup    string = "vmware.purser.com"
 	CRDVersion  string = "v1"
 	FullCRDName string = CRDPlural + "." + CRDGroup
 )

--- a/pkg/apis/groups/v1/types.go
+++ b/pkg/apis/groups/v1/types.go
@@ -26,7 +26,7 @@ import (
 // CRD Group attributes
 const (
 	CRDPlural   string = "groups"
-	CRDGroup    string = "purser"
+	CRDGroup    string = "vmware.purser"
 	CRDVersion  string = "v1"
 	FullCRDName string = CRDPlural + "." + CRDGroup
 )

--- a/pkg/apis/subscriber/v1/types.go
+++ b/pkg/apis/subscriber/v1/types.go
@@ -22,7 +22,7 @@ import meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // CRD Subscriber attributes
 const (
 	SubscriberPlural   string = "subscribers"
-	SubscriberGroup    string = "purser.subscriber"
+	SubscriberGroup    string = "vmware.purser.com"
 	SubscriberVersion  string = "v1"
 	SubscriberFullName string = SubscriberPlural + "." + SubscriberGroup
 )

--- a/pkg/apis/subscriber/v1/types.go
+++ b/pkg/apis/subscriber/v1/types.go
@@ -22,7 +22,7 @@ import meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // CRD Subscriber attributes
 const (
 	SubscriberPlural   string = "subscribers"
-	SubscriberGroup    string = "kuber.input"
+	SubscriberGroup    string = "subscriber"
 	SubscriberVersion  string = "v1"
 	SubscriberFullName string = SubscriberPlural + "." + SubscriberGroup
 )

--- a/pkg/apis/subscriber/v1/types.go
+++ b/pkg/apis/subscriber/v1/types.go
@@ -22,7 +22,7 @@ import meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // CRD Subscriber attributes
 const (
 	SubscriberPlural   string = "subscribers"
-	SubscriberGroup    string = "subscriber"
+	SubscriberGroup    string = "purser.subscriber"
 	SubscriberVersion  string = "v1"
 	SubscriberFullName string = SubscriberPlural + "." + SubscriberGroup
 )

--- a/pkg/client/clientset/typed/groups/v1/group.go
+++ b/pkg/client/clientset/typed/groups/v1/group.go
@@ -21,20 +21,19 @@ import (
 	"github.com/vmware/purser/pkg/apis/groups/v1"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 )
 
 // GroupInterface has client methods we need to access Group object
 type GroupInterface interface {
-	CreateGroup(obj *v1.Group) (*v1.Group, error)
-	UpdateGroup(obj *v1.Group) (*v1.Group, error)
-	DeleteGroup(name string, options *meta_v1.DeleteOptions) error
-	GetGroup(name string) (*v1.Group, error)
-	ListGroups(opts meta_v1.ListOptions) (*v1.GroupList, error)
-	NewListWatchGroup() *cache.ListWatch
+	Create(obj *v1.Group) (*v1.Group, error)
+	Update(obj *v1.Group) (*v1.Group, error)
+	Delete(name string, options *meta_v1.DeleteOptions) error
+	Get(name string) (*v1.Group, error)
+	List(opts meta_v1.ListOptions) (*v1.GroupList, error)
+	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
 }
 
 // GroupClient defines the CRD Group structure
@@ -45,18 +44,8 @@ type GroupClient struct {
 	codec  runtime.ParameterCodec
 }
 
-// NewGroup creates a new intance of the group CRD client.
-func NewGroup(client *rest.RESTClient, scheme *runtime.Scheme, namespace string) *GroupClient {
-	return &GroupClient{
-		client: client,
-		ns:     namespace,
-		plural: v1.CRDPlural,
-		codec:  runtime.NewParameterCodec(scheme),
-	}
-}
-
-// CreateGroup creates a new group.
-func (c *GroupClient) CreateGroup(obj *v1.Group) (*v1.Group, error) {
+// Create creates a new group.
+func (c *GroupClient) Create(obj *v1.Group) (*v1.Group, error) {
 	result := v1.Group{}
 	err := c.client.Post().
 		Namespace(c.ns).
@@ -67,8 +56,8 @@ func (c *GroupClient) CreateGroup(obj *v1.Group) (*v1.Group, error) {
 	return &result, err
 }
 
-// UpdateGroup modifies the group specification.
-func (c *GroupClient) UpdateGroup(obj *v1.Group) (*v1.Group, error) {
+// Update modifies the group specification.
+func (c *GroupClient) Update(obj *v1.Group) (*v1.Group, error) {
 	result := v1.Group{}
 	err := c.client.Put().
 		Name((obj.Name)).
@@ -80,8 +69,8 @@ func (c *GroupClient) UpdateGroup(obj *v1.Group) (*v1.Group, error) {
 	return &result, err
 }
 
-// DeleteGroup removes the group.
-func (c *GroupClient) DeleteGroup(name string, options *meta_v1.DeleteOptions) error {
+// Delete removes the group.
+func (c *GroupClient) Delete(name string, options *meta_v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource(c.plural).
@@ -91,8 +80,8 @@ func (c *GroupClient) DeleteGroup(name string, options *meta_v1.DeleteOptions) e
 		Error()
 }
 
-// GetGroup fetches the group
-func (c *GroupClient) GetGroup(name string) (*v1.Group, error) {
+// Get fetches the group
+func (c *GroupClient) Get(name string) (*v1.Group, error) {
 	result := v1.Group{}
 	err := c.client.Get().
 		Namespace(c.ns).
@@ -103,8 +92,8 @@ func (c *GroupClient) GetGroup(name string) (*v1.Group, error) {
 	return &result, err
 }
 
-// ListGroups fetches the list of groups.
-func (c *GroupClient) ListGroups(opts meta_v1.ListOptions) (*v1.GroupList, error) {
+// List fetches the list of groups.
+func (c *GroupClient) List(opts meta_v1.ListOptions) (*v1.GroupList, error) {
 	result := v1.GroupList{}
 	err := c.client.Get().
 		Namespace(c.ns).
@@ -115,7 +104,13 @@ func (c *GroupClient) ListGroups(opts meta_v1.ListOptions) (*v1.GroupList, error
 	return &result, err
 }
 
-// NewListWatchGroup creates a new List watch for our TPR
-func (c *GroupClient) NewListWatchGroup() *cache.ListWatch {
-	return cache.NewListWatchFromClient(c.client, c.plural, c.ns, fields.Everything())
+// Watch watches for the groups.
+func (c *GroupClient) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.
+		Get().
+		Namespace(c.ns).
+		Resource(c.plural).
+		VersionedParams(&opts, c.codec).
+		Watch()
 }

--- a/pkg/client/clientset/typed/groups/v1/group_client.go
+++ b/pkg/client/clientset/typed/groups/v1/group_client.go
@@ -51,7 +51,17 @@ func NewGroupClient(clientset apiextcs.Interface, config *rest.Config) *GroupCli
 	}
 
 	// Create a CRD client interface
-	return NewGroup(gcrdcs, gscheme, "default")
+	return Group(gcrdcs, gscheme, "default")
+}
+
+// Group returns a new instance of the Group CRD
+func Group(client *rest.RESTClient, scheme *runtime.Scheme, namespace string) *GroupClient {
+	return &GroupClient{
+		client: client,
+		ns:     namespace,
+		plural: groups_v1.CRDPlural,
+		codec:  runtime.NewParameterCodec(scheme),
+	}
 }
 
 func createGroupCRD(clientset apiextcs.Interface) error {

--- a/pkg/client/clientset/typed/subscriber/v1/subsciber_client.go
+++ b/pkg/client/clientset/typed/subscriber/v1/subsciber_client.go
@@ -51,7 +51,17 @@ func NewSubscriberClient(clientset apiextcs.Interface, config *rest.Config) *Sub
 	}
 
 	// Create a CRD client interface
-	return NewSubscriber(crdcs, scheme, "default")
+	return Subscriber(crdcs, scheme, "default")
+}
+
+// Subscriber returns an instance of the subscriber client
+func Subscriber(client *rest.RESTClient, scheme *runtime.Scheme, namespace string) *SubscriberClient {
+	return &SubscriberClient{
+		client: client,
+		ns:     namespace,
+		plural: subscriber_v1.SubscriberPlural,
+		codec:  runtime.NewParameterCodec(scheme),
+	}
 }
 
 func createSubscriberCRD(clientset apiextcs.Interface) error {

--- a/pkg/client/clientset/typed/subscriber/v1/subscriber.go
+++ b/pkg/client/clientset/typed/subscriber/v1/subscriber.go
@@ -21,20 +21,19 @@ import (
 	"github.com/vmware/purser/pkg/apis/subscriber/v1"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 )
 
 // SubscriberInterface has client methods we need to access Subscriber object
 type SubscriberInterface interface {
-	CreateSubscriber(obj *v1.Subscriber) (*v1.Subscriber, error)
-	UpdateSubscriber(obj *v1.Subscriber) (*v1.Subscriber, error)
-	DeleteSubscriber(name string, options *meta_v1.DeleteOptions) error
-	GetSubscriber(name string) (*v1.Subscriber, error)
-	ListSubscriber(opts meta_v1.ListOptions) (*v1.SubscriberList, error)
-	NewListWatchSubscriber() *cache.ListWatch
+	Create(obj *v1.Subscriber) (*v1.Subscriber, error)
+	Update(obj *v1.Subscriber) (*v1.Subscriber, error)
+	Delete(name string, options *meta_v1.DeleteOptions) error
+	Get(name string) (*v1.Subscriber, error)
+	List(opts meta_v1.ListOptions) (*v1.SubscriberList, error)
+	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
 }
 
 // SubscriberClient structure
@@ -45,18 +44,8 @@ type SubscriberClient struct {
 	codec  runtime.ParameterCodec
 }
 
-// NewSubscriber creates a new intance of the group CRD client.
-func NewSubscriber(client *rest.RESTClient, scheme *runtime.Scheme, namespace string) *SubscriberClient {
-	return &SubscriberClient{
-		client: client,
-		ns:     namespace,
-		plural: v1.SubscriberPlural,
-		codec:  runtime.NewParameterCodec(scheme),
-	}
-}
-
-// CreateSubscriber creates a CRD subscriber.
-func (c *SubscriberClient) CreateSubscriber(obj *v1.Subscriber) (*v1.Subscriber, error) {
+// Create creates a CRD subscriber.
+func (c *SubscriberClient) Create(obj *v1.Subscriber) (*v1.Subscriber, error) {
 	result := v1.Subscriber{}
 	err := c.client.Post().
 		Namespace(c.ns).
@@ -67,8 +56,8 @@ func (c *SubscriberClient) CreateSubscriber(obj *v1.Subscriber) (*v1.Subscriber,
 	return &result, err
 }
 
-// UpdateSubscriber modifies the subscriber.
-func (c *SubscriberClient) UpdateSubscriber(obj *v1.Subscriber) (*v1.Subscriber, error) {
+// Update modifies the subscriber.
+func (c *SubscriberClient) Update(obj *v1.Subscriber) (*v1.Subscriber, error) {
 	result := v1.Subscriber{}
 	err := c.client.Put().
 		Name((obj.Name)).
@@ -80,8 +69,8 @@ func (c *SubscriberClient) UpdateSubscriber(obj *v1.Subscriber) (*v1.Subscriber,
 	return &result, err
 }
 
-// DeleteSubscriber removes the subscriber.
-func (c *SubscriberClient) DeleteSubscriber(name string, options *meta_v1.DeleteOptions) error {
+// Delete removes the subscriber.
+func (c *SubscriberClient) Delete(name string, options *meta_v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource(c.plural).
@@ -91,8 +80,8 @@ func (c *SubscriberClient) DeleteSubscriber(name string, options *meta_v1.Delete
 		Error()
 }
 
-// GetSubscriber returns the subscriber
-func (c *SubscriberClient) GetSubscriber(name string) (*v1.Subscriber, error) {
+// Get returns the subscriber
+func (c *SubscriberClient) Get(name string) (*v1.Subscriber, error) {
 	result := v1.Subscriber{}
 	err := c.client.Get().
 		Namespace(c.ns).
@@ -103,8 +92,8 @@ func (c *SubscriberClient) GetSubscriber(name string) (*v1.Subscriber, error) {
 	return &result, err
 }
 
-// ListSubscriber fetches the list of subscriber CRD clients.
-func (c *SubscriberClient) ListSubscriber(opts meta_v1.ListOptions) (*v1.SubscriberList, error) {
+// List fetches the list of subscriber CRD clients.
+func (c *SubscriberClient) List(opts meta_v1.ListOptions) (*v1.SubscriberList, error) {
 	result := v1.SubscriberList{}
 	err := c.client.Get().
 		Namespace(c.ns).
@@ -115,7 +104,13 @@ func (c *SubscriberClient) ListSubscriber(opts meta_v1.ListOptions) (*v1.Subscri
 	return &result, err
 }
 
-// NewListWatchSubscriber creates a new List watch for our TPR
-func (c *SubscriberClient) NewListWatchSubscriber() *cache.ListWatch {
-	return cache.NewListWatchFromClient(c.client, c.plural, c.ns, fields.Everything())
+// Watch watches for the subcriber CRD
+func (c *SubscriberClient) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.
+		Get().
+		Namespace(c.ns).
+		Resource(c.plural).
+		VersionedParams(&opts, c.codec).
+		Watch()
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -338,6 +338,7 @@ func Start(conf *Config) {
 		)
 
 		c := newResourceController(Kubeclient, informer, "Group")
+		c.conf = conf
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -360,6 +361,7 @@ func Start(conf *Config) {
 		)
 
 		c := newResourceController(Kubeclient, informer, "Subscriber")
+		c.conf = conf
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/client"
+
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	subscriber_v1 "github.com/vmware/purser/pkg/client/clientset/typed/subscriber/v1"
@@ -44,7 +45,7 @@ func TestCrdFlow(t *testing.T) {
 
 // ListSubscriberCrdInstances fetches list of subscriber CRD instances.
 func ListSubscriberCrdInstances(crdclient *subscriber_v1.SubscriberClient) {
-	items, err := crdclient.ListSubscriber(meta_v1.ListOptions{})
+	items, err := crdclient.List(meta_v1.ListOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -43,7 +43,7 @@ func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 	newGroup := GroupCRD{
 		Name:          group.Name,
 		IsPurserGroup: true,
-		Type:          "purser",
+		Type:          "vmware.purser",
 		ID:            dgraph.ID{Xid: group.Name},
 		StartTime:     group.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import (
@@ -38,7 +55,7 @@ func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 	return newGroup
 }
 
-// StoreGroupCRD create a new persistent volume in the Dgraph and updates if already present.
+// StoreGroupCRD create a new group CRD in the Dgraph and updates if already present.
 func StoreGroupCRD(group groups_v1.Group) (string, error) {
 	xid := group.Name
 	uid := dgraph.GetUID(xid, IsPurserGroup)

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -43,7 +43,7 @@ func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 	newGroup := GroupCRD{
 		Name:          group.Name,
 		IsPurserGroup: true,
-		Type:          "vmware.purser",
+		Type:          groups_v1.CRDGroup,
 		ID:            dgraph.ID{Xid: group.Name},
 		StartTime:     group.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -15,11 +15,11 @@ const (
 // GroupCRD schema in dgraph
 type GroupCRD struct {
 	dgraph.ID
-	IsPurserGroup bool      `json:"isPurserGroup,omitempty"`
-	Name          string    `json:"name,omitempty"`
-	StartTime     time.Time `json:"startTime,omitempty"`
-	EndTime       time.Time `json:"endTime,omitempty"`
-	Type          string    `json:"type,omitempty"`
+	IsPurserGroup bool   `json:"isPurserGroup,omitempty"`
+	Name          string `json:"name,omitempty"`
+	StartTime     string `json:"startTime,omitempty"`
+	EndTime       string `json:"endTime,omitempty"`
+	Type          string `json:"type,omitempty"`
 }
 
 func createGroupCRDObject(group groups_v1.Group) GroupCRD {
@@ -28,12 +28,12 @@ func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 		IsPurserGroup: true,
 		Type:          "purser",
 		ID:            dgraph.ID{Xid: group.Name},
-		StartTime:     group.GetCreationTimestamp().Time,
+		StartTime:     group.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 
 	deletionTimestamp := group.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
-		newGroup.EndTime = deletionTimestamp.Time
+		newGroup.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newGroup
 }

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"time"
+
+	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+)
+
+// Dgraph Model Constants
+const (
+	IsGroupCRD = "isGroupCRD"
+)
+
+// GroupCRD schema in dgraph
+type GroupCRD struct {
+	dgraph.ID
+	IsGroupCRD bool      `json:"isGroupCRD,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	StartTime  time.Time `json:"startTime,omitempty"`
+	EndTime    time.Time `json:"endTime,omitempty"`
+	Type       string    `json:"type,omitempty"`
+}
+
+func createGroupCRDObject(group groups_v1.Group) GroupCRD {
+	newGroup := GroupCRD{
+		Name:       group.Name,
+		IsGroupCRD: true,
+		Type:       "vmware.kuber",
+		ID:         dgraph.ID{Xid: group.Name},
+		StartTime:  group.GetCreationTimestamp().Time,
+	}
+
+	deletionTimestamp := group.GetDeletionTimestamp()
+	if !deletionTimestamp.IsZero() {
+		newGroup.EndTime = deletionTimestamp.Time
+	}
+	return newGroup
+}
+
+// StoreGroupCRD create a new persistent volume in the Dgraph and updates if already present.
+func StoreGroupCRD(group groups_v1.Group) (string, error) {
+	xid := group.Name
+	uid := dgraph.GetUID(xid, IsGroupCRD)
+
+	newGroup := createGroupCRDObject(group)
+	if uid != "" {
+		newGroup.UID = uid
+	}
+	assigned, err := dgraph.MutateNode(newGroup, dgraph.CREATE)
+	if err != nil {
+		return "", err
+	}
+	return assigned.Uids["blank-0"], nil
+}

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -9,26 +9,26 @@ import (
 
 // Dgraph Model Constants
 const (
-	IsGroupCRD = "isGroupCRD"
+	IsPurserGroup = "isPurserGroup"
 )
 
 // GroupCRD schema in dgraph
 type GroupCRD struct {
 	dgraph.ID
-	IsGroupCRD bool      `json:"isGroupCRD,omitempty"`
-	Name       string    `json:"name,omitempty"`
-	StartTime  time.Time `json:"startTime,omitempty"`
-	EndTime    time.Time `json:"endTime,omitempty"`
-	Type       string    `json:"type,omitempty"`
+	IsPurserGroup bool      `json:"isPurserGroup,omitempty"`
+	Name          string    `json:"name,omitempty"`
+	StartTime     time.Time `json:"startTime,omitempty"`
+	EndTime       time.Time `json:"endTime,omitempty"`
+	Type          string    `json:"type,omitempty"`
 }
 
 func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 	newGroup := GroupCRD{
-		Name:       group.Name,
-		IsGroupCRD: true,
-		Type:       "vmware.kuber",
-		ID:         dgraph.ID{Xid: group.Name},
-		StartTime:  group.GetCreationTimestamp().Time,
+		Name:          group.Name,
+		IsPurserGroup: true,
+		Type:          "purser",
+		ID:            dgraph.ID{Xid: group.Name},
+		StartTime:     group.GetCreationTimestamp().Time,
 	}
 
 	deletionTimestamp := group.GetDeletionTimestamp()
@@ -41,7 +41,7 @@ func createGroupCRDObject(group groups_v1.Group) GroupCRD {
 // StoreGroupCRD create a new persistent volume in the Dgraph and updates if already present.
 func StoreGroupCRD(group groups_v1.Group) (string, error) {
 	xid := group.Name
-	uid := dgraph.GetUID(xid, IsGroupCRD)
+	uid := dgraph.GetUID(xid, IsPurserGroup)
 
 	newGroup := createGroupCRDObject(group)
 	if uid != "" {

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -15,11 +15,11 @@ const (
 // SubscriberCRD schema in dgraph
 type SubscriberCRD struct {
 	dgraph.ID
-	IsSubscriberCRD bool      `json:"isSubscriberCRD,omitempty"`
-	Name            string    `json:"name,omitempty"`
-	StartTime       time.Time `json:"startTime,omitempty"`
-	EndTime         time.Time `json:"endTime,omitempty"`
-	Type            string    `json:"type,omitempty"`
+	IsSubscriberCRD bool   `json:"isSubscriberCRD,omitempty"`
+	Name            string `json:"name,omitempty"`
+	StartTime       string `json:"startTime,omitempty"`
+	EndTime         string `json:"endTime,omitempty"`
+	Type            string `json:"type,omitempty"`
 }
 
 func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberCRD {
@@ -28,12 +28,12 @@ func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberC
 		IsSubscriberCRD: true,
 		Type:            "subscriber",
 		ID:              dgraph.ID{Xid: subscriber.Name},
-		StartTime:       subscriber.GetCreationTimestamp().Time,
+		StartTime:       subscriber.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 
 	deletionTimestamp := subscriber.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
-		newSubscriber.EndTime = deletionTimestamp.Time
+		newSubscriber.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 	}
 	return newSubscriber
 }

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -43,7 +43,7 @@ func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberC
 	newSubscriber := SubscriberCRD{
 		Name:         subscriber.Name,
 		IsSubscriber: true,
-		Type:         "purser.subscriber",
+		Type:         subscribers_v1.SubscriberGroup,
 		ID:           dgraph.ID{Xid: subscriber.Name},
 		StartTime:    subscriber.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import (
@@ -9,26 +26,26 @@ import (
 
 // Dgraph Model Constants
 const (
-	IsSubscriberCRD = "isSubscriberCRD"
+	IsSubscriber = "isSubscriber"
 )
 
 // SubscriberCRD schema in dgraph
 type SubscriberCRD struct {
 	dgraph.ID
-	IsSubscriberCRD bool   `json:"isSubscriberCRD,omitempty"`
-	Name            string `json:"name,omitempty"`
-	StartTime       string `json:"startTime,omitempty"`
-	EndTime         string `json:"endTime,omitempty"`
-	Type            string `json:"type,omitempty"`
+	IsSubscriber bool   `json:"isSubscriber,omitempty"`
+	Name         string `json:"name,omitempty"`
+	StartTime    string `json:"startTime,omitempty"`
+	EndTime      string `json:"endTime,omitempty"`
+	Type         string `json:"type,omitempty"`
 }
 
 func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberCRD {
 	newSubscriber := SubscriberCRD{
-		Name:            subscriber.Name,
-		IsSubscriberCRD: true,
-		Type:            "subscriber",
-		ID:              dgraph.ID{Xid: subscriber.Name},
-		StartTime:       subscriber.GetCreationTimestamp().Time.Format(time.RFC3339),
+		Name:         subscriber.Name,
+		IsSubscriber: true,
+		Type:         "subscriber",
+		ID:           dgraph.ID{Xid: subscriber.Name},
+		StartTime:    subscriber.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}
 
 	deletionTimestamp := subscriber.GetDeletionTimestamp()
@@ -38,10 +55,10 @@ func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberC
 	return newSubscriber
 }
 
-// StoreSubscriberCRD create a new persistent volume in the Dgraph and updates if already present.
+// StoreSubscriberCRD create a new subscriber CRD in the Dgraph and updates if already present.
 func StoreSubscriberCRD(subscriber subscribers_v1.Subscriber) (string, error) {
 	xid := subscriber.Name
-	uid := dgraph.GetUID(xid, IsSubscriberCRD)
+	uid := dgraph.GetUID(xid, IsSubscriber)
 
 	newSubscriber := createSubscriberCRDObject(subscriber)
 	if uid != "" {

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -43,7 +43,7 @@ func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberC
 	newSubscriber := SubscriberCRD{
 		Name:         subscriber.Name,
 		IsSubscriber: true,
-		Type:         "subscriber",
+		Type:         "purser.subscriber",
 		ID:           dgraph.ID{Xid: subscriber.Name},
 		StartTime:    subscriber.GetCreationTimestamp().Time.Format(time.RFC3339),
 	}

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -26,7 +26,7 @@ func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberC
 	newSubscriber := SubscriberCRD{
 		Name:            subscriber.Name,
 		IsSubscriberCRD: true,
-		Type:            "kuber.input",
+		Type:            "subscriber",
 		ID:              dgraph.ID{Xid: subscriber.Name},
 		StartTime:       subscriber.GetCreationTimestamp().Time,
 	}

--- a/pkg/controller/dgraph/models/subscriber.go
+++ b/pkg/controller/dgraph/models/subscriber.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"time"
+
+	subscribers_v1 "github.com/vmware/purser/pkg/apis/subscriber/v1"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+)
+
+// Dgraph Model Constants
+const (
+	IsSubscriberCRD = "isSubscriberCRD"
+)
+
+// SubscriberCRD schema in dgraph
+type SubscriberCRD struct {
+	dgraph.ID
+	IsSubscriberCRD bool      `json:"isSubscriberCRD,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	StartTime       time.Time `json:"startTime,omitempty"`
+	EndTime         time.Time `json:"endTime,omitempty"`
+	Type            string    `json:"type,omitempty"`
+}
+
+func createSubscriberCRDObject(subscriber subscribers_v1.Subscriber) SubscriberCRD {
+	newSubscriber := SubscriberCRD{
+		Name:            subscriber.Name,
+		IsSubscriberCRD: true,
+		Type:            "kuber.input",
+		ID:              dgraph.ID{Xid: subscriber.Name},
+		StartTime:       subscriber.GetCreationTimestamp().Time,
+	}
+
+	deletionTimestamp := subscriber.GetDeletionTimestamp()
+	if !deletionTimestamp.IsZero() {
+		newSubscriber.EndTime = deletionTimestamp.Time
+	}
+	return newSubscriber
+}
+
+// StoreSubscriberCRD create a new persistent volume in the Dgraph and updates if already present.
+func StoreSubscriberCRD(subscriber subscribers_v1.Subscriber) (string, error) {
+	xid := subscriber.Name
+	uid := dgraph.GetUID(xid, IsSubscriberCRD)
+
+	newSubscriber := createSubscriberCRDObject(subscriber)
+	if uid != "" {
+		newSubscriber.UID = uid
+	}
+	assigned, err := dgraph.MutateNode(newSubscriber, dgraph.CREATE)
+	if err != nil {
+		return "", err
+	}
+	return assigned.Uids["blank-0"], nil
+}

--- a/pkg/controller/discovery/processor/cluster.go
+++ b/pkg/controller/discovery/processor/cluster.go
@@ -19,10 +19,15 @@ package processor
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
+
+	groupsv1 "github.com/vmware/purser/pkg/apis/groups/v1"
+	subscriberv1 "github.com/vmware/purser/pkg/apis/subscriber/v1"
+	groups "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
+	subscriber "github.com/vmware/purser/pkg/client/clientset/typed/subscriber/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // RetrievePodList returns list of pods in the given namespace.
@@ -41,4 +46,22 @@ func RetrieveServiceList(client *kubernetes.Clientset, options metav1.ListOption
 		log.Errorf("failed to retrieve services: %v", err)
 	}
 	return services
+}
+
+// RetrieveSubscriberList returns list of subscribers in the given namespace.
+func RetrieveSubscriberList(subscriberClient *subscriber.SubscriberClient, options metav1.ListOptions) *subscriberv1.SubscriberList {
+	subscribers, err := subscriberClient.List(options)
+	if err != nil {
+		log.Errorf("failed to retrieve subscriber list: %v ", err)
+	}
+	return subscribers
+}
+
+// RetrieveGroupList returns list of group CRDs in the given namespace.
+func RetrieveGroupList(groupClient *groups.GroupClient, options metav1.ListOptions) *groupsv1.GroupList {
+	groups, err := groupClient.List(options)
+	if err != nil {
+		log.Errorf("failed to retrieve group list: %v ", err)
+	}
+	return groups
 }

--- a/pkg/controller/eventprocessor/notifier.go
+++ b/pkg/controller/eventprocessor/notifier.go
@@ -87,7 +87,7 @@ func (subscriber *subscriber) setAuthHeaders(r *http.Request) {
 
 func getSubscribers(conf *controller.Config) []*subscriber {
 	subscribers := []*subscriber{}
-	list, err := conf.Subscriberclient.ListSubscriber(meta_v1.ListOptions{})
+	list, err := conf.Subscriberclient.List(meta_v1.ListOptions{})
 	if err != nil {
 		log.Error("Error while fetching subscribers list ", err)
 		return nil

--- a/pkg/controller/eventprocessor/processor.go
+++ b/pkg/controller/eventprocessor/processor.go
@@ -25,6 +25,8 @@ import (
 	"github.com/vmware/purser/pkg/controller/dgraph/models"
 
 	log "github.com/Sirupsen/logrus"
+	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
+	subcriber_v1 "github.com/vmware/purser/pkg/apis/subscriber/v1"
 	apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	batch_v1 "k8s.io/api/batch/v1"
 	api_v1 "k8s.io/api/core/v1"
@@ -180,6 +182,26 @@ func PersistPayloads(payloads []*interface{}) {
 			_, err = models.StoreJob(job)
 			if err != nil {
 				log.Errorf("Error while persisting job %v", err)
+			}
+		} else if payload.ResourceType == "Group" {
+			groupCRD := groups_v1.Group{}
+			err := json.Unmarshal([]byte(payload.Data), &groupCRD)
+			if err != nil {
+				log.Errorf("Error un marshalling payload " + payload.Data)
+			}
+			_, err = models.StoreGroupCRD(groupCRD)
+			if err != nil {
+				log.Errorf("Error while persisting group CRD %v", err)
+			}
+		} else if payload.ResourceType == "Subscriber" {
+			subscriberCRD := subcriber_v1.Subscriber{}
+			err := json.Unmarshal([]byte(payload.Data), &subscriberCRD)
+			if err != nil {
+				log.Errorf("Error un marshalling payload " + payload.Data)
+			}
+			_, err = models.StoreSubscriberCRD(subscriberCRD)
+			if err != nil {
+				log.Errorf("Error while persisting subscriber CRD %v", err)
 			}
 		}
 	}

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -36,7 +36,7 @@ func updateCustomGroups(payloads []*interface{}, groups []*groups_v1.Group, crdc
 
 	// update all the groups
 	for _, group := range groups {
-		_, err := crdclient.UpdateGroup(group)
+		_, err := crdclient.Update(group)
 
 		if err != nil {
 			log.Errorf("There is an error while updating the crd for group = "+group.Name, err)
@@ -147,7 +147,7 @@ func isPodBelongsToGroup(group *groups_v1.Group, pod *api_v1.Pod) bool {
 }
 
 func getAllGroups(crdclient *groups_client_v1.GroupClient) []*groups_v1.Group {
-	items, err := crdclient.ListGroups(meta_v1.ListOptions{})
+	items, err := crdclient.List(meta_v1.ListOptions{})
 	if err != nil {
 		log.Error("Error while fetching groups ", err)
 		return nil

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -45,8 +45,8 @@ type Resource struct {
 	Job                   bool `json:"job"`
 	DaemonSet             bool `json:"daemonset"`
 	Namespace             bool `json:"namespace"`
-	Group                 bool `json:"vmware.kuber"`
-	Subscriber            bool `json:"kuber.input"`
+	Group                 bool `json:"purser"`
+	Subscriber            bool `json:"subscriber"`
 }
 
 // Config contains config objects

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -45,8 +45,8 @@ type Resource struct {
 	Job                   bool `json:"job"`
 	DaemonSet             bool `json:"daemonset"`
 	Namespace             bool `json:"namespace"`
-	Group                 bool `json:"vmware.purser"`
-	Subscriber            bool `json:"purser.subscriber"`
+	Group                 bool `json:"groups.vmware.purser.com"`
+	Subscriber            bool `json:"subscribers.vmware.purser.com"`
 }
 
 // Config contains config objects

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -45,8 +45,8 @@ type Resource struct {
 	Job                   bool `json:"job"`
 	DaemonSet             bool `json:"daemonset"`
 	Namespace             bool `json:"namespace"`
-	Group                 bool `json:"purser"`
-	Subscriber            bool `json:"subscriber"`
+	Group                 bool `json:"vmware.purser"`
+	Subscriber            bool `json:"purser.subscriber"`
 }
 
 // Config contains config objects

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -45,6 +45,8 @@ type Resource struct {
 	Job                   bool `json:"job"`
 	DaemonSet             bool `json:"daemonset"`
 	Namespace             bool `json:"namespace"`
+	Group                 bool `json:"vmware.kuber"`
+	Subscriber            bool `json:"kuber.input"`
 }
 
 // Config contains config objects

--- a/pkg/plugin/grouping.go
+++ b/pkg/plugin/grouping.go
@@ -20,26 +20,23 @@ package plugin
 import (
 	"fmt"
 
+	log "github.com/Sirupsen/logrus"
+
 	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
-	groups_client_v1 "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
+	groups "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
 	"github.com/vmware/purser/pkg/plugin/metrics"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetGroupByName return group CRD by name.
-func GetGroupByName(crdclient *groups_client_v1.GroupClient, groupName string) *groups_v1.Group {
-	group, err := crdclient.GetGroup(groupName)
-
-	if err == nil {
-		return group
-	} else if apierrors.IsNotFound(err) {
-		return nil
-	} else {
-		panic(err)
+func GetGroupByName(groupClient *groups.GroupClient, groupName string) *groups_v1.Group {
+	group, err := groupClient.Get(groupName)
+	if err != nil {
+		log.Errorf("failed to get custom group by name %s, %v", groupName, err)
 	}
+	return group
 }
 
 // GetGroupDetails returns aggregated metrics (cpu, memory, storage) and cost (total, cpu, memory and storage) of a Group


### PR DESCRIPTION
This PR aims at enhancing the handling for CRDs by reducing the number of Kubernetes APIs calls for fetching CRDs details by listening for CRD updates and persisting them in memory.

- [x] Adds informers(listeners) for CRDs.
- [x] Persist CRDs in Dgraph.
- [ ] Write Dgraph queries to retrieve CRDs.
- [x] Update CRDs(Groups) in memory.

Fixes #91 

