### PR TITLE
Add support for user preferences

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -4,5 +4,3 @@ LABEL maintainer = "VMware <hkatyal@vmware.com>"
 LABEL author = "Hemani Katyal <hkatyal@vmware.com>"
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
-
-ENTRYPOINT ["/ARG_BIN"]

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ CMD := cmd/controller
 
 # Where to push the docker image.
 REGISTRY?=docker.io
-DOCKER_REPO?=kreddyj
+DOCKER_REPO?=vmwareh
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH?= amd64
 
 # This version-strategy uses a manual value to set the version string
-VERSION := 1.0.0-test
+VERSION := 1.0.0
 
 ###
 ### These variables should not need tweaking.

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ CMD := cmd/controller
 
 # Where to push the docker image.
 REGISTRY?=docker.io
-DOCKER_REPO?=vmwareh
+DOCKER_REPO?=kreddyj
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH?= amd64
 
 # This version-strategy uses a manual value to set the version string
-VERSION := 1.0.0
+VERSION := 1.0.0-test
 
 ###
 ### These variables should not need tweaking.

--- a/README.md
+++ b/README.md
@@ -66,18 +66,16 @@ Purser has three components to install.
 
 #### Purser Controller Setup
 Download the controller setup yaml file from [here](./cluster/purser-controller-setup.yaml).
-
-**To enable/disable Purser features**
-
-Edit [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml)
-* Choose **log level** by editing `args` of purser-controller deployment (default: info)
-* Enable/Disable discovery of **interactions** feature by editing `args` of purser-controller deployment 
-and uncommenting `pods/exec` rule from purser-permissions (default: disabled)
-* Change **dgraph's** url and port number by editing `args` of purser-controller deployment (default: purser-db, 9080)
 ``` bash
 # Controller installation
 kubectl create -f purser-controller-setup.yaml
 ```
+
+**To enable/disable Purser features edit [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml) before installing**
+* Choose **log level** by editing `args` of purser-controller deployment (default: info)
+* Enable/Disable discovery of **interactions** feature by editing `args` of purser-controller deployment 
+and uncommenting `pods/exec` rule from purser-permissions (default: disabled)
+* Change **dgraph's** url and port number by editing `args` of purser-controller deployment (default: purser-db, 9080)
 
 #### Purser UI Setup
 Download the UI setup yaml file from [here](./cluster/purser-ui-setup.yaml).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Purser has three components to install.
 
 #### Purser Controller Setup
 Download the controller setup yaml file from [here](./cluster/purser-controller-setup.yaml).
+
+**To enable/disable Purser features**
+
+Edit [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml)
+* Choose **log level** by editing `args` of purser-controller deployment (default: info)
+* Enable/Disable discovery of **interactions** feature by editing `args` of purser-controller deployment 
+and uncommenting `pods/exec` rule from purser-permissions (default: disabled)
+* Change **dgraph's** url and port number by editing `args` of purser-controller deployment (default: purser-db, 9080)
 ``` bash
 # Controller installation
 kubectl create -f purser-controller-setup.yaml

--- a/cluster/purser-controller-setup.yaml
+++ b/cluster/purser-controller-setup.yaml
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: purser-service-account
       containers:
       - name: purser-controller
-        image: kreddyj/controller-amd64:1.0.0
+        image: kreddyj/controller-amd64:1.0.0-test
         imagePullPolicy: Always
         resources:
           limits:
@@ -193,3 +193,5 @@ spec:
         ports:
         - containerPort: 3030
           name: purser
+        args: ["--log", "debug", "--interactions", "true", "--dgraphURL", "purser-db", "--dgraphPort", "9080"]
+

--- a/cluster/purser-controller-setup.yaml
+++ b/cluster/purser-controller-setup.yaml
@@ -194,5 +194,5 @@ spec:
         - containerPort: 3030
           name: purser
         command: ["/controller"]
-        args: ["--log", "info", "--interactions", "false", "--dgraphURL", "purser-db", "--dgraphPort", "9080"]
+        args: ["--log=info", "--interactions=disable", "--dgraphURL=purser-db", "--dgraphPort=9080"]
 

--- a/cluster/purser-controller-setup.yaml
+++ b/cluster/purser-controller-setup.yaml
@@ -193,5 +193,6 @@ spec:
         ports:
         - containerPort: 3030
           name: purser
-        args: ["--log", "debug", "--interactions", "true", "--dgraphURL", "purser-db", "--dgraphPort", "9080"]
+        command: ["/controller"]
+        args: ["--log", "info", "--interactions", "false", "--dgraphURL", "purser-db", "--dgraphPort", "9080"]
 

--- a/cluster/purser-controller-setup.yaml
+++ b/cluster/purser-controller-setup.yaml
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: purser-service-account
       containers:
       - name: purser-controller
-        image: kreddyj/controller-amd64:1.0.0-test
+        image: kreddyj/controller-amd64:1.0.1
         imagePullPolicy: Always
         resources:
           limits:

--- a/cluster/purser-controller-setup.yaml
+++ b/cluster/purser-controller-setup.yaml
@@ -17,9 +17,10 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["*"]
-    resources: ["pods/exec"]
-    verbs: ["create"]
+# Uncomment next three lines to enable interactions feature.
+#  - apiGroups: ["*"]
+#    resources: ["pods/exec"]
+#    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -18,7 +18,6 @@
 package config
 
 import (
-	"flag"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -31,16 +31,11 @@ import (
 	"github.com/vmware/purser/pkg/utils"
 )
 
-// InClusterConfigPath should be empty to get client and config for InCluster environment.
-const InClusterConfigPath = ""
-
 // Setup initialzes the controller configuration
-func Setup(conf *controller.Config) {
-	kubeconfig := flag.String("kubeconfig", InClusterConfigPath, "path to the kubeconfig file")
-	flag.Parse()
+func Setup(conf *controller.Config, kubeconfig string) {
 	var err error
 	*conf = controller.Config{}
-	conf.KubeConfig, err = utils.GetKubeconfig(*kubeconfig)
+	conf.KubeConfig, err = utils.GetKubeconfig(kubeconfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -61,7 +56,7 @@ func Setup(conf *controller.Config) {
 		Subscriber:            true,
 	}
 	conf.RingBuffer = &buffering.RingBuffer{Size: buffering.BufferSize, Mutex: &sync.Mutex{}}
-	clientset, clusterConfig := client.GetAPIExtensionClient(*kubeconfig)
+	clientset, clusterConfig := client.GetAPIExtensionClient(kubeconfig)
 	conf.Groupcrdclient = group_client.NewGroupClient(clientset, clusterConfig)
 	conf.Subscriberclient = subscriber_client.NewSubscriberClient(clientset, clusterConfig)
 }

--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -35,14 +35,21 @@ import (
 
 var conf controller.Config
 
+// InClusterConfigPath should be empty to get client and config for InCluster environment.
+const InClusterConfigPath = ""
+
+var interactions *string
+
 func init() {
 	logLevel := flag.String("log", "info", "set log level as info or debug")
-	utils.InitializeLogger(*logLevel)
-
-	config.Setup(&conf)
-
 	dgraphURL := flag.String("dgraphURL", "purser-db", "dgraph zero url")
 	dgraphPort := flag.String("dgraphPort", "9080", "dgraph zero port")
+	interactions = flag.String("interactions", "false", "enable discovery of interactions")
+	kubeconfig := flag.String("kubeconfig", InClusterConfigPath, "path to the kubeconfig file")
+	flag.Parse()
+
+	utils.InitializeLogger(*logLevel)
+	config.Setup(&conf, *kubeconfig)
 	dgraph.Start(*dgraphURL, *dgraphPort)
 }
 
@@ -50,7 +57,6 @@ func main() {
 	go api.StartServer()
 	go eventprocessor.ProcessEvents(&conf)
 
-	interactions := flag.String("interactions", "false", "enable discovery of interactions")
 	if *interactions == "true" {
 		go startInteractionsDiscovery()
 	}

--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -44,7 +44,7 @@ func init() {
 	logLevel := flag.String("log", "info", "set log level as info or debug")
 	dgraphURL := flag.String("dgraphURL", "purser-db", "dgraph zero url")
 	dgraphPort := flag.String("dgraphPort", "9080", "dgraph zero port")
-	interactions = flag.String("interactions", "false", "enable discovery of interactions")
+	interactions = flag.String("interactions", "disable", "enable discovery of interactions")
 	kubeconfig := flag.String("kubeconfig", InClusterConfigPath, "path to the kubeconfig file")
 	flag.Parse()
 
@@ -57,7 +57,7 @@ func main() {
 	go api.StartServer()
 	go eventprocessor.ProcessEvents(&conf)
 
-	if *interactions == "true" {
+	if *interactions == "enable" {
 		go startInteractionsDiscovery()
 	}
 

--- a/pkg/controller/dgraph/dgraph.go
+++ b/pkg/controller/dgraph/dgraph.go
@@ -49,15 +49,15 @@ type ID struct {
 	UID string `json:"uid,omitempty"`
 }
 
-func init() {
-	err := Open("purser-db:9080")
+func Start(url string, port string) {
+	err := Open(url + ":" + port)
 	if err != nil {
-		fmt.Println("Error while opening connection to Dgraph ", err)
+		fmt.Errorf("Error while opening connection to Dgraph ", err)
 	}
 
 	err = CreateSchema()
 	if err != nil {
-		fmt.Println("Error while creating schema ", err)
+		fmt.Errorf("Error while creating schema ", err)
 	}
 }
 

--- a/pkg/controller/dgraph/dgraph.go
+++ b/pkg/controller/dgraph/dgraph.go
@@ -49,15 +49,16 @@ type ID struct {
 	UID string `json:"uid,omitempty"`
 }
 
+// Start opens and creates schema in dgraph
 func Start(url string, port string) {
 	err := Open(url + ":" + port)
 	if err != nil {
-		fmt.Errorf("Error while opening connection to Dgraph ", err)
+		log.Errorf("error while opening connection to Dgraph: %v", err)
 	}
 
 	err = CreateSchema()
 	if err != nil {
-		fmt.Errorf("Error while creating schema ", err)
+		log.Errorf("error while creating schema: %v", err)
 	}
 }
 

--- a/pkg/utils/logutil.go
+++ b/pkg/utils/logutil.go
@@ -27,10 +27,15 @@ import (
 const logFile = "purser.log"
 
 // InitializeLogger sets and configures logger options.
-func InitializeLogger() {
+func InitializeLogger(logLevel string) {
 	logFile := OpenFile(logFile)
 
 	log.SetOutput(io.MultiWriter(os.Stdout, logFile))
 	log.SetFormatter(&log.TextFormatter{ForceColors: true})
-	log.SetLevel(log.InfoLevel)
+
+	if logLevel == "debug" {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Supports the following user preferences via flags
- choosing log level
- enabling/disabling discovery of interactions feature
- change dgraph url and port number

**Which issue(s) this PR fixes** :
Fixes #51
