### PR TITLE
Attempt 3 retries before failing subscriber notifications

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -433,14 +433,6 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:cc9f0c72e45707522afc156b3d715443e2021acedff165a4803f72a0d2ed170f"
-  name = "gopkg.in/matryer/try.v1"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "312d2599e12e89ca89b52a09597394f449235d80"
-  version = "v1"
-
-[[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -631,7 +623,6 @@
     "github.com/gorilla/mux",
     "github.com/robfig/cron",
     "google.golang.org/grpc",
-    "gopkg.in/matryer/try.v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -433,6 +433,14 @@
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:cc9f0c72e45707522afc156b3d715443e2021acedff165a4803f72a0d2ed170f"
+  name = "gopkg.in/matryer/try.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "312d2599e12e89ca89b52a09597394f449235d80"
+  version = "v1"
+
+[[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -623,6 +631,7 @@
     "github.com/gorilla/mux",
     "github.com/robfig/cron",
     "google.golang.org/grpc",
+    "gopkg.in/matryer/try.v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",

--- a/pkg/controller/dgraph/models/query/cluster.go
+++ b/pkg/controller/dgraph/models/query/cluster.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"

--- a/pkg/controller/dgraph/models/query/container.go
+++ b/pkg/controller/dgraph/models/query/container.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/daemonset.go
+++ b/pkg/controller/dgraph/models/query/daemonset.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/deployment.go
+++ b/pkg/controller/dgraph/models/query/deployment.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/job.go
+++ b/pkg/controller/dgraph/models/query/job.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/namespace.go
+++ b/pkg/controller/dgraph/models/query/namespace.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"

--- a/pkg/controller/dgraph/models/query/node.go
+++ b/pkg/controller/dgraph/models/query/node.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/dgraph/models"

--- a/pkg/controller/dgraph/models/query/pv.go
+++ b/pkg/controller/dgraph/models/query/pv.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/pvc.go
+++ b/pkg/controller/dgraph/models/query/pvc.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/replicaset.go
+++ b/pkg/controller/dgraph/models/query/replicaset.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/dgraph/models/query/statefulset.go
+++ b/pkg/controller/dgraph/models/query/statefulset.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )

--- a/pkg/controller/eventprocessor/notifier.go
+++ b/pkg/controller/eventprocessor/notifier.go
@@ -85,14 +85,14 @@ func sendData(req *http.Request) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("error sending data to %s: %v", req.RequestURI, err)
+		return fmt.Errorf("error sending data to %v: %v", req.URL, err)
 	}
 
 	if resp != nil {
 		if resp.StatusCode != 200 {
-			return fmt.Errorf("payload data posting failed for %s, %s", req.RequestURI, resp.Status)
+			return fmt.Errorf("payload data posting failed for %v, %s", req.URL, resp.Status)
 		}
-		log.Infof("Payload data posted successfully for %s", req.RequestURI)
+		log.Debugf("Payload data posted successfully for %v", req.URL)
 	}
 	return nil
 }

--- a/pkg/controller/eventprocessor/notifier.go
+++ b/pkg/controller/eventprocessor/notifier.go
@@ -60,7 +60,7 @@ func notifySubscribers(payload []*interface{}, subscribers *subscriber_v1.Subscr
 	}
 }
 
-func (n notifier) createNewRequest(payload []*interface{}) (*http.Request,error){
+func (n notifier) createNewRequest(payload []*interface{}) (*http.Request, error) {
 	payloadWrapper := controller.PayloadWrapper{
 		Data:    payload,
 		OrgID:   n.orgID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements retry capability with 3 attempts when sending(notifying) inventory updates to a subscriber, in the event of the webhook failure to send notification to subscriber(s).

**Which issue(s) this PR fixes** 
Fixes #116 


