### PR TITLE
 Store labels of pods in dgraph

### DIFF
--- a/pkg/controller/dgraph/models/label.go
+++ b/pkg/controller/dgraph/models/label.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+)
+
+// Dgraph Model Constants
+const (
+	Islabel = "isLabel"
+)
+
+// Label structure for Key:Value
+type Label struct {
+	dgraph.ID
+	IsLabel bool   `json:"isLabel,omitempty"`
+	Key     string `json:"key,omitempty"`
+	Value   string `json:"key,omitempty"`
+}
+
+// GetLabel if label is not in dgraph it creates and returns Label object
+func GetLabel(key, value string) *Label {
+	xid := getXIDOfLabel(key, value)
+	uid := CreateOrGetLabelByID(key, value)
+	return &Label{
+		ID: dgraph.ID{Xid: xid, UID: uid},
+	}
+}
+
+// CreateOrGetLabelByID if label is not in dgraph it creates and returns uid of label
+func CreateOrGetLabelByID(key, value string) string {
+	xid := getXIDOfLabel(key, value)
+	uid := dgraph.GetUID(xid, Islabel)
+	if uid == "" {
+		// create new label and get its uid
+		uid = createLabelObject(key, value)
+	}
+	return uid
+}
+
+func getXIDOfLabel(key, value string) string {
+	return "label-" + key + "-" + value
+}
+
+func createLabelObject(key, value string) string {
+	xid := getXIDOfLabel(key, value)
+	newLabel := Label{
+		ID:      dgraph.ID{Xid: xid},
+		IsLabel: true,
+		Key:     key,
+		Value:   value,
+	}
+	assigned, err := dgraph.MutateNode(newLabel, dgraph.CREATE)
+	if err != nil {
+		logrus.Fatal(err)
+		return ""
+	}
+	return assigned.Uids["blank-0"]
+}

--- a/pkg/controller/dgraph/models/label.go
+++ b/pkg/controller/dgraph/models/label.go
@@ -32,7 +32,7 @@ type Label struct {
 	dgraph.ID
 	IsLabel bool   `json:"isLabel,omitempty"`
 	Key     string `json:"key,omitempty"`
-	Value   string `json:"key,omitempty"`
+	Value   string `json:"value,omitempty"`
 }
 
 // GetLabel if label is not in dgraph it creates and returns Label object

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -59,6 +59,7 @@ type Pod struct {
 	StorageRequest float64                  `json:"storageRequest,omitempty"`
 	Type           string                   `json:"type,omitempty"`
 	Cid            []Service                `json:"cid,omitempty"`
+	Labels         []*Label                 `json:"label,omitempty"`
 }
 
 // Metrics ...
@@ -125,6 +126,7 @@ func StorePod(k8sPod api_v1.Pod) error {
 			MemoryRequest: metrics.MemoryRequest,
 			MemoryLimit:   metrics.MemoryLimit,
 		}
+		populatePodLabels(&pod, k8sPod.Labels)
 	}
 
 	_, err := dgraph.MutateNode(pod, dgraph.UPDATE)
@@ -245,4 +247,12 @@ func getPodVolumes(k8sPod api_v1.Pod) ([]*PersistentVolumeClaim, float64) {
 		}
 	}
 	return podVolumes, storage
+}
+
+func populatePodLabels(pod *Pod, podLabels map[string]string) {
+	var labels []*Label
+	for key, value := range podLabels {
+		labels = append(labels, GetLabel(key, value))
+	}
+	pod.Labels = labels
 }

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -105,16 +105,16 @@ func updatePodDetails(group *groups_v1.Group, pod api_v1.Pod, payload controller
 
 func getContainerWithMetrics(cont api_v1.Container) *groups_v1.Container {
 	container := groups_v1.Container{Name: cont.Name}
-	metrics := metrics.Metrics{}
+	containerMetrics := metrics.Metrics{}
 	if cont.Resources.Requests != nil {
-		metrics.CPURequest = cont.Resources.Requests.Cpu()
-		metrics.MemoryRequest = cont.Resources.Requests.Memory()
+		containerMetrics.CPURequest = cont.Resources.Requests.Cpu()
+		containerMetrics.MemoryRequest = cont.Resources.Requests.Memory()
 	}
 	if cont.Resources.Limits != nil {
-		metrics.CPULimit = cont.Resources.Limits.Cpu()
-		metrics.MemoryLimit = cont.Resources.Limits.Memory()
+		containerMetrics.CPULimit = cont.Resources.Limits.Cpu()
+		containerMetrics.MemoryLimit = cont.Resources.Limits.Memory()
 	}
-	container.Metrics = &metrics
+	container.Metrics = &containerMetrics
 	return &container
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we create dgraph edges from pod to labels which will be useful to query for pods based on labels.

**Which issue(s) this PR fixes**:
Fixes a task in #124 