### PR TITLE
Add custom headers support for Subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Purser with it's robust CLI and UI capabilities provides a set of features inclu
  
  - A plugin extension to `kubectl` along with the UI for developer centric usage.
  
- - Capability to notify inventory changes via web-hook implementation. 
+ - Capability to subscribe to inventory changes via web-hook implementation. 
 
 ### Purser UI demo
 
@@ -66,19 +66,24 @@ Purser has three components to install.
 
 #### Purser Controller Setup
 Download the controller setup yaml file from [here](./cluster/purser-controller-setup.yaml).
+
 ``` bash
 # Controller installation
 kubectl create -f purser-controller-setup.yaml
 ```
 
-**To enable/disable Purser features edit [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml) before installing**
-* Choose **log level** by editing `args` of purser-controller deployment (default: info)
-* Enable/Disable discovery of **interactions** feature by editing `args` of purser-controller deployment 
-and uncommenting `pods/exec` rule from purser-permissions (default: disabled)
-* Change **dgraph's** url and port number by editing `args` of purser-controller deployment (default: purser-db, 9080)
+##### Change Settings and Enable/Disable Purser Features
+
+The following settings can be customized before Controller installation:
+
+- Change the default **log level**, **dgraph url** and **dgraph port** by editing `args` field in the [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml). (Default: `--log=info`, `--dgraphURL=purser-db`, `--dgraphPort=9080`)
+- Enable/Disable **resource interactions** capability by editing `args` field in the [purser-controller-setup.yaml](./cluster/purser-controller-setup.yaml) and uncommenting `pods/exec` rule from purser-permissions. (Default: `disabled`)
+- Enable **subscription to inventory changes** capability by creating an object of custom resource kind `Subscriber`. (Refer: [example-subscriber.yaml](./cluster/artifacts/example-subscriber.yaml))
+- Enable **customized logical grouping of resources** by creating an object of custom resource kind `Group`. (Refer: [example-group.yaml](./cluster/artifacts/example-group.yaml))
 
 #### Purser UI Setup
 Download the UI setup yaml file from [here](./cluster/purser-ui-setup.yaml).
+
 ``` bash
 # UI installation
 kubectl create -f purser-ui-setup.yaml
@@ -108,12 +113,14 @@ For other installation methods such as **manual installation** or **installation
 ## Uninstalling
 
 ### Uninstalling Purser Controller
+
 ``` bash
 kubectl delete -f purser-controller-setup.yaml
 kubectl delete pvc datadir-dgraph-0
 ```
 
 ### Uninstalling Purser UI
+
 ``` bash
 kubectl delete -f purser-ui-setup.yaml
 ```

--- a/cluster/artifacts/example-subscriber.yaml
+++ b/cluster/artifacts/example-subscriber.yaml
@@ -4,8 +4,7 @@ metadata:
   name: example-subscriber
 spec:
   name: example-subscriber
-  cspOrgId: <optional>
-  cluster: <your-cluster-name>
-  authType: access-token
-  authToken: <your-token>
+  headers:
+    authorization: "Bearer <your-token>"
+    cluster: "<your-cluster-name>"
   url: <your-webhook-url>

--- a/pkg/apis/subscriber/v1/types.go
+++ b/pkg/apis/subscriber/v1/types.go
@@ -37,12 +37,9 @@ type Subscriber struct {
 
 // SubscriberSpec definition details
 type SubscriberSpec struct {
-	Name        string `json:"name"`
-	ClusterName string `json:"cluster"`
-	OrgID       string `json:"orgId"`
-	URL         string `json:"url"`
-	AuthType    string `json:"authType,omitempty"`
-	AuthToken   string `json:"authToken,omitempty"`
+	Name    string            `json:"name"`
+	Headers map[string]string `json:"headers"`
+	URL     string            `json:"url"`
 }
 
 // SubscriberStatus definition

--- a/pkg/controller/payload.go
+++ b/pkg/controller/payload.go
@@ -21,8 +21,6 @@ import meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // PayloadWrapper holds additional information about payload
 type PayloadWrapper struct {
-	OrgID   string         `json:"orgId"`
-	Cluster string         `json:"cluster"`
 	Data    []*interface{} `json:"data"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces support for setting custom headers such as different authorization headers for `Subscribers` giving more flexibility at the hands of the user. 

**Which issue(s) this PR fixes**
Fixes #117 

