### PR TITLE
Persist PV's storage type in dgraph

### DIFF
--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -31,8 +31,8 @@ import (
 // Dgraph Model Constants
 const (
 	IsNode               = "isNode"
-	DefaultNodeInstance  = "default"
-	DefaultNodeOS        = "default"
+	DefaultNodeInstance  = "purser-default"
+	DefaultNodeOS        = "purser-default"
 	InstanceTypeLabelKey = "beta.kubernetes.io/instance-type"
 	OSLabelKey           = "beta.kubernetes.io/os"
 )
@@ -45,7 +45,7 @@ type Node struct {
 	StartTime      string  `json:"startTime,omitempty"`
 	EndTime        string  `json:"endTime,omitempty"`
 	Pods           []*Pod  `json:"pods,omitempty"`
-	CPUCapity      float64 `json:"cpuCapacity,omitempty"`
+	CPUCapacity    float64 `json:"cpuCapacity,omitempty"`
 	MemoryCapacity float64 `json:"memoryCapacity,omitempty"`
 	Type           string  `json:"type,omitempty"`
 	InstanceType   string  `json:"instanceType,omitempty"`
@@ -59,7 +59,7 @@ func createNodeObject(node api_v1.Node) Node {
 		Type:           "node",
 		ID:             dgraph.ID{Xid: node.Name},
 		StartTime:      node.GetCreationTimestamp().Time.Format(time.RFC3339),
-		CPUCapity:      utils.ConvertToFloat64CPU(node.Status.Capacity.Cpu()),
+		CPUCapacity:    utils.ConvertToFloat64CPU(node.Status.Capacity.Cpu()),
 		MemoryCapacity: utils.ConvertToFloat64GB(node.Status.Capacity.Memory()),
 	}
 

--- a/pkg/controller/discovery/processor/pod.go
+++ b/pkg/controller/discovery/processor/pod.go
@@ -18,6 +18,7 @@
 package processor
 
 import (
+	"github.com/vmware/purser/pkg/controller/utils"
 	"sync"
 
 	"github.com/vmware/purser/pkg/controller"
@@ -36,7 +37,7 @@ var wg sync.WaitGroup
 // ProcessPodInteractions fetches details of all the running processes in each container of
 // each pod in a given namespace and generates a 1:1 mapping between the communicating pods.
 func ProcessPodInteractions(conf controller.Config) {
-	k8sPods := RetrievePodList(conf.Kubeclient, metav1.ListOptions{})
+	k8sPods := utils.RetrievePodList(conf.Kubeclient, metav1.ListOptions{})
 	if k8sPods == nil {
 		log.Info("No pods retrieved from cluster")
 		return

--- a/pkg/controller/discovery/processor/svc.go
+++ b/pkg/controller/discovery/processor/svc.go
@@ -18,6 +18,7 @@
 package processor
 
 import (
+	"github.com/vmware/purser/pkg/controller/utils"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -36,7 +37,7 @@ var svcwg sync.WaitGroup
 // ProcessServiceInteractions parses through the list of services and it's associated pods to
 // generate a 1:1 mapping between the communicating services.
 func ProcessServiceInteractions(conf controller.Config) {
-	services := RetrieveServiceList(conf.Kubeclient, metav1.ListOptions{})
+	services := utils.RetrieveServiceList(conf.Kubeclient, metav1.ListOptions{})
 	if services == nil {
 		log.Info("No services retrieved from cluster")
 		return
@@ -65,7 +66,7 @@ func processServiceDetails(client *kubernetes.Clientset, services *corev1.Servic
 					options := metav1.ListOptions{
 						LabelSelector: selectorSet.AsSelector().String(),
 					}
-					pods := RetrievePodList(client, options)
+					pods := utils.RetrievePodList(client, options)
 					if pods != nil {
 						linker.PopulatePodToServiceTable(svc, pods)
 					}

--- a/pkg/controller/eventprocessor/processor.go
+++ b/pkg/controller/eventprocessor/processor.go
@@ -146,7 +146,7 @@ func ProcessPayloads(payloads []*interface{}, conf *controller.Config) {
 			if err != nil {
 				log.Errorf("Error un marshalling payload " + payload.Data)
 			}
-			_, err = models.StorePersistentVolume(pv)
+			_, err = models.StorePersistentVolume(pv, conf.Kubeclient)
 			if err != nil {
 				log.Errorf("Error while persisting persistent volume %v", err)
 			}

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -19,7 +19,7 @@ package eventprocessor
 
 import (
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
-	"github.com/vmware/purser/pkg/controller/discovery/processor"
+	"github.com/vmware/purser/pkg/controller/utils"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -32,7 +32,7 @@ import (
 // UpdateGroups retrieve all groups and updates them
 func UpdateGroups(groupCRDClient *groupsClient_v1.GroupClient) {
 	log.Infof("Started updating groups")
-	groups := processor.RetrieveGroupList(groupCRDClient, meta_v1.ListOptions{})
+	groups := utils.RetrieveGroupList(groupCRDClient, meta_v1.ListOptions{})
 	if groups == nil {
 		log.Debugf("GroupList is nil")
 		return

--- a/pkg/controller/utils/k8sUtils.go
+++ b/pkg/controller/utils/k8sUtils.go
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-package processor
+package utils
 
 import (
 	log "github.com/Sirupsen/logrus"
+	storagev1 "k8s.io/api/storage/v1"
 
 	groupsv1 "github.com/vmware/purser/pkg/apis/groups/v1"
 	groups "github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
@@ -56,4 +57,14 @@ func RetrieveGroupList(groupClient *groups.GroupClient, options metav1.ListOptio
 		return nil
 	}
 	return crdGroups
+}
+
+// RetrieveStorageClass returns storage class with the given name. Nil if error is encountered
+func RetrieveStorageClass(client *kubernetes.Clientset, options metav1.GetOptions, name string) (*storagev1.StorageClass, error) {
+	storageClass, err := client.StorageV1().StorageClasses().Get(name, options)
+	if err != nil {
+		log.Errorf("failed to retrieve storage class: %s, err: %v", name, err)
+		return nil, err
+	}
+	return storageClass, err
 }

--- a/pkg/controller/utils/k8sUtils.go
+++ b/pkg/controller/utils/k8sUtils.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// k8sUtils constants
 const (
 	StorageDefault = "purser-default"
 )
@@ -74,7 +75,7 @@ func RetrieveStorageClass(client *kubernetes.Clientset, options metav1.GetOption
 	return storageClass, err
 }
 
-// GetStorageType ...
+// GetFinalStorageTypeOfPV ...
 // input: persistent volume
 // output: the type(final) of PV's storage class
 // i.e., if PV has storage class A, A is of type B(storage class) and so on..
@@ -95,9 +96,8 @@ func GetFinalStorageTypeOfPV(pv api_v1.PersistentVolume, client *kubernetes.Clie
 func getFinalTypeOfStorageClass(client *kubernetes.Clientset, storageClassName string, cycleChecker map[string]bool) string {
 	if _, isVisited := cycleChecker[storageClassName]; isVisited {
 		return StorageDefault
-	} else {
-		cycleChecker[storageClassName] = true
 	}
+	cycleChecker[storageClassName] = true
 
 	storageClass, err := RetrieveStorageClass(client, metav1.GetOptions{}, storageClassName)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR PVs will have new field storage type.
This also refactors some files: fixes spell errors and move k8s common functions into utils.

**Which issue(s) this PR fixes**:
Fixes #142 

**Special notes for your reviewer**:
Tested on a cluster running on `aws`