### PR TITLE
Retrieve and filter price list for AWS

### DIFF
--- a/pkg/controller/dgraph/models/rateCard.go
+++ b/pkg/controller/dgraph/models/rateCard.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import "github.com/vmware/purser/pkg/controller/dgraph"
+
+// RateCard structure
+type RateCard struct {
+	dgraph.ID
+	IsRateCard    bool            `json:"isRateCard,omitempty"`
+	CloudProvider string          `json:"cloudProvider,omitempty"`
+	Region        string          `json:"region,omitempty"`
+	NodePrices    []*NodePrice    `json:"nodePrices,omitempty"`
+	StoragePrices []*StoragePrice `json:"storagePrices,omitempty"`
+}
+
+// NodePrice structure
+// Unit of Node Price should be USD($)-(per Hour)
+type NodePrice struct {
+	dgraph.ID
+	IsNodePrice     bool    `json:"isNodePrice,omitempty"`
+	InstanceType    string  `json:"instanceType,omitempty"`
+	InstanceFamily  string  `json:"instanceFamily,omitempty"`
+	OperatingSystem string  `json:"operatingSystem,omitempty"`
+	Price           float64 `json:"price,omitempty"`
+}
+
+// StoragePrice structure
+// Unit of Storage Price should be USD($)-(per GB)-(per Hour)
+type StoragePrice struct {
+	dgraph.ID
+	IsStoragePrice bool    `json:"isStoragePrice,omitempty"`
+	VolumeType     string  `json:"volumeType,omitempty"`
+	UsageType      string  `json:"usageType,omitempty"`
+	Price          float64 `json:"price,omitempty"`
+}
+
+// TODO: store/update rate card in dgraph

--- a/pkg/controller/utils/jsonutils.go
+++ b/pkg/controller/utils/jsonutils.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"encoding/json"
+	"net/http"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -30,4 +31,23 @@ func JSONMarshal(obj interface{}) []byte {
 		log.Error(err)
 	}
 	return bytes
+}
+
+// GetJSONResponse retrieves json response and converts it to target object.
+// Returns error if any failure is encountered.
+func GetJSONResponse(client *http.Client, url string, target interface{}) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer closeResponse(resp)
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func closeResponse(resp *http.Response) {
+	err := resp.Body.Close()
+	if err != nil {
+		log.Errorf("unable to close response body. Reason: %v", err)
+	}
 }

--- a/pkg/pricing/aws/aws.go
+++ b/pkg/pricing/aws/aws.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aws
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/utils"
+	"net/http"
+	"time"
+)
+
+// Pricing structure
+type Pricing struct {
+	Products map[string]Product
+	Terms    PlanList
+}
+
+// PlanList structure
+type PlanList struct {
+	OnDemand map[string]map[string]TermAttributes
+}
+
+// TermAttributes structure
+type TermAttributes struct {
+	PriceDimensions map[string]PricingData
+}
+
+// PricingData structure
+type PricingData struct {
+	Unit         string
+	PricePerUnit map[string]string
+}
+
+// Product structure
+type Product struct {
+	Sku           string
+	ProductFamily string
+	Attributes    ProductAttributes
+}
+
+// ProductAttributes structure
+type ProductAttributes struct {
+	InstanceType    string
+	InstanceFamily  string
+	OperatingSystem string
+	PreInstalledSW  string
+	VolumeType      string
+	UsageType       string
+}
+
+// GetAWSPricing function details
+// input: region
+// retrieves data from http get to the corresponding url for that region
+func GetAWSPricing(region string) (*Pricing, error) {
+	var myClient = &http.Client{Timeout: 100 * time.Second}
+	rateCard := Pricing{}
+	err := utils.GetJSONResponse(myClient, getURLForRegion(region), &rateCard)
+	if err != nil {
+		logrus.Errorf("Unable to get aws pricing. Reason: %v", err)
+		return nil, err
+	}
+	return &rateCard, nil
+}
+
+func getURLForRegion(region string) string {
+	return "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/" + region + "/index.json"
+}

--- a/pkg/pricing/aws/aws.go
+++ b/pkg/pricing/aws/aws.go
@@ -18,10 +18,15 @@
 package aws
 
 import (
-	"github.com/Sirupsen/logrus"
-	"github.com/vmware/purser/pkg/controller/utils"
 	"net/http"
 	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/utils"
+)
+
+const (
+	httpTimeout = 100 * time.Second
 )
 
 // Pricing structure
@@ -67,7 +72,7 @@ type ProductAttributes struct {
 // input: region
 // retrieves data from http get to the corresponding url for that region
 func GetAWSPricing(region string) (*Pricing, error) {
-	var myClient = &http.Client{Timeout: 100 * time.Second}
+	var myClient = &http.Client{Timeout: httpTimeout}
 	rateCard := Pricing{}
 	err := utils.GetJSONResponse(myClient, getURLForRegion(region), &rateCard)
 	if err != nil {

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aws
+
+import (
+	"strconv"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+)
+
+const (
+	na              = "na"
+	aws             = "aws"
+	gbMonth         = "GB-Mo"
+	deliminator     = "-"
+	storageInstance = "Storage"
+	computeInstance = "Compute Instance"
+)
+
+// GetRateCardForAWS takes region as input and returns RateCard and error if any
+func GetRateCardForAWS(region string) (*models.RateCard, error) {
+	awsPricing, err := GetAWSPricing(region)
+	if err != nil {
+		return nil, err
+	}
+	rateCard := convertAWSPricingToPurserRateCard(region, awsPricing)
+	return rateCard, nil
+}
+
+func convertAWSPricingToPurserRateCard(region string, awsPricing *Pricing) *models.RateCard {
+	nodePrice, storagePrice := getResourcePricesFromAWSPricing(awsPricing)
+	return &models.RateCard{
+		IsRateCard:    true,
+		CloudProvider: aws,
+		Region:        region,
+		NodePrices:    nodePrice,
+		StoragePrices: storagePrice,
+	}
+}
+
+func getResourcePricesFromAWSPricing(awsPricing *Pricing) ([]*models.NodePrice, []*models.StoragePrice) {
+	var nodePrices []*models.NodePrice
+	var storagePrices []*models.StoragePrice
+	products := awsPricing.Products
+	planList := awsPricing.Terms
+
+	duplicateComputeInstanceChecker := make(map[string]bool)
+	for _, product := range products {
+		if product.ProductFamily == computeInstance {
+			key := product.Sku + product.Attributes.InstanceType + product.Attributes.OperatingSystem
+			if _, isPresent := duplicateComputeInstanceChecker[key]; !isPresent && product.Attributes.PreInstalledSW == na {
+				nodePrice := getComputeInstancePrice(product, planList)
+				if nodePrice != nil {
+					duplicateComputeInstanceChecker[key] = true
+					logrus.Debugf("Node Price: %v", *nodePrice)
+					// TODO: store/update nodePrice in dgraph
+					nodePrices = append(nodePrices, nodePrice)
+				}
+			}
+		} else if product.ProductFamily == storageInstance {
+			storagePrice := getStorageInstancePrice(product, planList)
+			if storagePrice != nil {
+				logrus.Debugf("Storage Price: %v", *storagePrice)
+				// TODO: store/update storagePrice in dgraph
+				storagePrices = append(storagePrices, storagePrice)
+			}
+		}
+	}
+	return nodePrices, storagePrices
+}
+
+func getComputeInstancePrice(product Product, planList PlanList) *models.NodePrice {
+	for _, pricingAttributes := range planList.OnDemand[product.Sku] {
+		for _, pricingData := range pricingAttributes.PriceDimensions {
+			for _, pricePerUnit := range pricingData.PricePerUnit {
+				priceInFloat64, err := strconv.ParseFloat(pricePerUnit, 64)
+				if err != nil {
+					logrus.Errorf("unable to parse string: %s to float. err: %v", pricePerUnit, err)
+					return nil
+				}
+				// Unit of Compute price USD-perHour
+				productXID := product.Attributes.InstanceType + deliminator + product.Attributes.InstanceFamily + deliminator + product.Attributes.OperatingSystem
+				return &models.NodePrice{
+					ID:              dgraph.ID{Xid: productXID},
+					IsNodePrice:     true,
+					InstanceType:    product.Attributes.InstanceType,
+					InstanceFamily:  product.Attributes.InstanceFamily,
+					OperatingSystem: product.Attributes.OperatingSystem,
+					Price:           priceInFloat64,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getStorageInstancePrice(product Product, planList PlanList) *models.StoragePrice {
+	for _, pricingAttributes := range planList.OnDemand[product.Sku] {
+		for _, pricingData := range pricingAttributes.PriceDimensions {
+			for _, pricePerUnit := range pricingData.PricePerUnit {
+				priceInFloat64, err := strconv.ParseFloat(pricePerUnit, 64)
+				if err != nil {
+					logrus.Errorf("unable to parse string: %s to float. err: %v", pricePerUnit, err)
+					return nil
+				}
+				if pricingData.Unit == gbMonth {
+					// convert to GBHour
+					priceInFloat64 = priceInFloat64 / (30 * 24)
+				}
+				productXID := product.Attributes.VolumeType + deliminator + product.Attributes.UsageType
+				return &models.StoragePrice{
+					ID:             dgraph.ID{Xid: productXID},
+					IsStoragePrice: true,
+					VolumeType:     product.Attributes.VolumeType,
+					UsageType:      product.Attributes.UsageType,
+					Price:          priceInFloat64,
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>AppDApp</title>
+  <title>Purser</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit defines the RateCard structure that Purser follows and
it retrieves aws pricing.

**Which issue(s) this PR fixes**:
Fixes a task in #145 

AWS pricing api for `us-east-1`: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-1/index.json