### PR TITLE
API support for custom groups

### DIFF
--- a/cmd/controller/api/handlers.go
+++ b/cmd/controller/api/handlers.go
@@ -432,13 +432,22 @@ func GetPodDiscoveryNodes(w http.ResponseWriter, r *http.Request) {
 func GetPodDiscoveryEdges(w http.ResponseWriter, r *http.Request) {
 	var err error
 	addHeaders(&w, r)
-	if err != nil {
-		logrus.Errorf("Unable to get response: (%v)", err)
-	}
 
 	err = json.NewEncoder(w).Encode(generator.GetGraphEdges())
 	if err != nil {
 		logrus.Errorf("Unable to encode to json: (%v)", err)
+	}
+}
+
+// GetGroupsData listens on /groups endpoint
+func GetGroupsData(w http.ResponseWriter, r *http.Request) {
+	addHeaders(&w, r)
+
+	groupsData, err := query.RetrieveGroupsData()
+	if err != nil {
+		logrus.Errorf("unable to retrieve groups data from dgraph, %v", err)
+	} else {
+		encodeAndWrite(w, groupsData)
 	}
 }
 

--- a/cmd/controller/api/routes.go
+++ b/cmd/controller/api/routes.go
@@ -207,4 +207,10 @@ var routes = Routes{
 		"/edges",
 		GetPodDiscoveryEdges,
 	},
+	Route{
+		"GetGroupsData",
+		"GET",
+		"/groups",
+		GetGroupsData,
+	},
 }

--- a/pkg/controller/dgraph/dgraph.go
+++ b/pkg/controller/dgraph/dgraph.go
@@ -96,6 +96,7 @@ func CreateSchema() error {
 		isPod: bool .
 		isContainer: bool .
 		isProc: bool .
+		isGroup: bool .
 		isNodePrice: bool .
 		isStoragePrice: bool .
 		isRateCard: bool .

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -18,8 +18,6 @@
 package models
 
 import (
-	"time"
-
 	"github.com/dgraph-io/dgo/protos/api"
 	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
 	"github.com/vmware/purser/pkg/controller/dgraph"
@@ -35,8 +33,6 @@ type Group struct {
 	dgraph.ID
 	IsGroup        bool    `json:"isGroup,omitempty"`
 	Name           string  `json:"name,omitempty"`
-	StartTime      string  `json:"startTime,omitempty"`
-	EndTime        string  `json:"endTime,omitempty"`
 	PodsCount      int     `json:"podsCount,omitempty"`
 	MtdCPU         float64 `json:"mtdCPU,omitempty"`
 	MtdMemory      float64 `json:"mtdMemory,omitempty"`
@@ -59,8 +55,6 @@ func CreateOrUpdateGroup(group *groups_v1.Group, podsCount int) (*api.Assigned, 
 		ID:             dgraph.ID{Xid: xid},
 		IsGroup:        true,
 		Name:           group.Name,
-		StartTime:      group.GetCreationTimestamp().Time.Format(time.RFC3339),
-		EndTime:        group.GetDeletionTimestamp().Time.Format(time.RFC3339),
 		PodsCount:      podsCount,
 		MtdCPU:         group.Spec.MTDMetrics.CPURequest,
 		MtdMemory:      group.Spec.MTDMetrics.MemoryRequest,

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import (
+	"time"
+
+	"github.com/dgraph-io/dgo/protos/api"
+	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+)
+
+const (
+	IsGroup   = "isGroup"
+	XIDPrefix = "purser-group-"
+)
+
+// Group schema in dgraph
+type Group struct {
+	dgraph.ID
+	IsGroup        bool    `json:"isGroup,omitempty"`
+	Name           string  `json:"name,omitempty"`
+	StartTime      string  `json:"startTime,omitempty"`
+	EndTime        string  `json:"endTime,omitempty"`
+	PodsCount      int     `json:"podsCount,omitempty"`
+	MtdCPU         float64 `json:"mtdCPU,omitempty"`
+	MtdMemory      float64 `json:"mtdMemory,omitempty"`
+	MtdStorage     float64 `json:"mtdStorage,omitempty"`
+	CPU            float64 `json:"cpu,omitempty"`
+	Memory         float64 `json:"memory,omitempty"`
+	Storage        float64 `json:"storage,omitempty"`
+	MtdCPUCost     float64 `json:"mtdCPUCost,omitempty"`
+	MtdMemoryCost  float64 `json:"mtdMemoryCost,omitempty"`
+	MtdStorageCost float64 `json:"mtdStorageCost,omitempty"`
+	MtdCost        float64 `json:"mtdCost,omitempty"`
+}
+
+// CreateOrUpdateGroup updates group if it is already present in dgraph else it creates one
+func CreateOrUpdateGroup(group *groups_v1.Group, podsCount int) (*api.Assigned, error) {
+	xid := XIDPrefix + group.Name
+	uid := dgraph.GetUID(xid, IsGroup)
+
+	grp := Group{
+		ID:             dgraph.ID{Xid: xid},
+		IsGroup:        true,
+		Name:           group.Name,
+		StartTime:      group.GetCreationTimestamp().Time.Format(time.RFC3339),
+		EndTime:        group.GetDeletionTimestamp().Time.Format(time.RFC3339),
+		PodsCount:      podsCount,
+		MtdCPU:         group.Spec.MTDMetrics.CPURequest,
+		MtdMemory:      group.Spec.MTDMetrics.MemoryRequest,
+		MtdStorage:     group.Spec.MTDMetrics.StorageClaim,
+		CPU:            group.Spec.PITMetrics.CPURequest,
+		Memory:         group.Spec.PITMetrics.MemoryRequest,
+		Storage:        group.Spec.PITMetrics.StorageClaim,
+		MtdCPUCost:     group.Spec.MTDCost.CPUCost,
+		MtdMemoryCost:  group.Spec.MTDCost.MemoryCost,
+		MtdStorageCost: group.Spec.MTDCost.StorageCost,
+		MtdCost:        group.Spec.MTDCost.TotalCost,
+	}
+	if uid != "" {
+		grp.ID = dgraph.ID{Xid: xid, UID: uid}
+	}
+	return dgraph.MutateNode(grp, dgraph.CREATE)
+}

--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"
@@ -39,6 +40,7 @@ type GroupMetrics struct {
 	CostCPU        float64
 	CostMemory     float64
 	CostStorage    float64
+	PodsCount      int
 }
 
 // RetrieveGroupMetricsFromPodUIDs ...

--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"
@@ -41,6 +43,34 @@ type GroupMetrics struct {
 	CostMemory     float64
 	CostStorage    float64
 	PodsCount      int
+}
+
+// RetrieveGroupsData returns list of models.Group objects in json format
+// error is not nil if any failure is encountered
+func RetrieveGroupsData() ([]models.Group, error) {
+	query := `query {
+		groups(func: has(isGroup)) {
+			name
+			podsCount
+			mtdCPU
+			mtdMemory
+			mtdStorage
+			cpu
+			memory
+			storage
+			mtdCPUCost
+			mtdMemoryCost
+			mtdStorageCost
+			mtdCost
+		}
+	}`
+
+	type root struct {
+		Groups []models.Group `json:groups`
+	}
+	newRoot := root{}
+	err := dgraph.ExecuteQuery(query, &newRoot)
+	return newRoot.Groups, err
 }
 
 // RetrieveGroupMetricsFromPodUIDs ...

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -18,9 +18,12 @@
 package eventprocessor
 
 import (
+	"time"
+
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
 	"github.com/vmware/purser/pkg/controller/utils"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -75,6 +78,11 @@ func UpdateGroup(group *groups_v1.Group, groupCRDClient *groupsClient_v1.GroupCl
 		log.Debugf("Updated group spec: (%v)", group.Spec)
 		log.Infof("Group spec is updated with metrics for group: (%s)", group.Name)
 	}
+
+	_, err = models.CreateOrUpdateGroup(group, groupMetrics.PodsCount)
+	if err != nil {
+		log.Errorf("unable to create or update group in dgraph: (%s), error: (%v)", group.Name, err)
+	}
 }
 
 func getGroupMetrics(group *groups_v1.Group) query.GroupMetrics {
@@ -90,7 +98,7 @@ func getGroupMetrics(group *groups_v1.Group) query.GroupMetrics {
 
 	// if number of occurrences of UID == number of expressions that means the pod satisfies all the expressions(i.e, AND)
 	// get uid-query to retrieve such pods i.e, "uid1, uid2, uid2..."
-	uidQueryForPods := getUIDQueryForPods(podUIDsCounter, len(group.Spec.Expressions))
+	uidQueryForPods, podsCount := getUIDQueryForPods(podUIDsCounter, len(group.Spec.Expressions))
 	log.Debugf("Group: (%v), uidQuery: (%v)", group.Name, uidQueryForPods)
 
 	// get group metrics
@@ -99,6 +107,7 @@ func getGroupMetrics(group *groups_v1.Group) query.GroupMetrics {
 		log.Errorf("Unable to retrieve group metrics. UIDs: (%v)", uidQueryForPods)
 		return query.GroupMetrics{}
 	}
+	groupMetrics.PodsCount = podsCount
 	return groupMetrics
 }
 
@@ -133,9 +142,10 @@ func mapPodUIDsToNumberOfOccurences(podsFromExpressions [][]string) map[string]i
 // returns UIDs for pods that satisfy (number of its occurrences == expressions count) i.e,
 // if number of occurrences of UID == number of expressions that means the pod satisfies all the expressions(-> AND)
 // returns uid-query(i.e, "uid1, uid2, uid2...") that can retrieve desired pods
-func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) string {
+func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) (string, int) {
 	separator := ", "
 	isFirst := true
+	podsCount := 0
 	var uidQueryForPods string
 	for podUID, count := range podsUIDsCounter {
 		if count == expressionsCount {
@@ -145,7 +155,8 @@ func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) st
 				isFirst = false
 			}
 			uidQueryForPods += podUID
+			podsCount++
 		}
 	}
-	return uidQueryForPods
+	return uidQueryForPods, podsCount
 }

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -77,11 +77,10 @@ func UpdateGroup(group *groups_v1.Group, groupCRDClient *groupsClient_v1.GroupCl
 	} else {
 		log.Debugf("Updated group spec: (%v)", group.Spec)
 		log.Infof("Group spec is updated with metrics for group: (%s)", group.Name)
-	}
-
-	_, err = models.CreateOrUpdateGroup(group, groupMetrics.PodsCount)
-	if err != nil {
-		log.Errorf("unable to create or update group in dgraph: (%s), error: (%v)", group.Name, err)
+		_, err = models.CreateOrUpdateGroup(group, groupMetrics.PodsCount)
+		if err != nil {
+			log.Errorf("unable to create or update group in dgraph: (%s), error: (%v)", group.Name, err)
+		}
 	}
 }
 

--- a/ui/src/app/modules/capacity-graph/components/capactiy-graph.component.html
+++ b/ui/src/app/modules/capacity-graph/components/capactiy-graph.component.html
@@ -60,8 +60,8 @@
                                     <tr>
                                         <td class="left">{{rootItem.name || '-'}}</td>
                                         <td class="left">{{rootItem.type || '-'}}</td>
-                                        <td class="right" *ngFor="let item of metricOptions">{{rootItem[item.value] || 0}}</td>
-                                        <td class="right" *ngFor="let item of metricOptions">{{rootItem[item.value+'Cost'] || 0}}</td>
+                                        <td class="right" *ngFor="let item of metricOptions">{{rootItem[item.value] | number: '1.0-2' || 0}}</td>
+                                        <td class="right" *ngFor="let item of metricOptions">{{rootItem[item.value+'Cost'] | number: '1.0-2' || 0}}</td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/ui/src/app/modules/capacity-graph/components/capactiy-graph.component.ts
+++ b/ui/src/app/modules/capacity-graph/components/capactiy-graph.component.ts
@@ -76,7 +76,7 @@ export class CapactiyGraphComponent implements OnInit {
         let metricValue = capaData[this.selectedMetric] || 0;
         let metricCostValue = capaData[this.selectedMetric + 'Cost'] || 0;
         if (rootName) {
-            eachRow.push({ v: rootName, f: rootName + ', ' + this.selectedMetric + ': ' + metricValue + ', ' + this.selectedMetric + ' cost: ' + metricCostValue });
+            eachRow.push({ v: rootName, f: rootName + ', ' + this.selectedMetric + ': ' + metricValue.toFixed(2) + ', ' + this.selectedMetric + ' cost: ' + metricCostValue.toFixed(2) });
             eachRow.push(null);
             eachRow.push(0);
             if (this.uniqNames.indexOf(rootName) === -1) {
@@ -91,7 +91,7 @@ export class CapactiyGraphComponent implements OnInit {
         let parentName = item.name === parent.name ? parent.type : parent.name;
         let metricValue = item[this.selectedMetric] || 0;
         let metricCostValue = item[this.selectedMetric + 'Cost'] || 0;
-        eachRow.push({ v: item.name, f: item.name + ', ' + this.selectedMetric + ': ' + metricValue + ', ' + this.selectedMetric + ' cost: ' + metricCostValue, t: item.type });
+        eachRow.push({ v: item.name, f: item.name + ', ' + this.selectedMetric + ': ' + metricValue.toFixed(2) + ', ' + this.selectedMetric + ' cost: ' + metricCostValue.toFixed(2), t: item.type });
         eachRow.push(parentName);
         eachRow.push(metricValue);
         if (this.uniqNames.indexOf(item.name) === -1) {

--- a/ui/src/app/modules/logical-group/components/logical-group.component.html
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.html
@@ -4,6 +4,9 @@
     <clr-dg-column [clrDgField]="'cpu'">CPU (vCPU)</clr-dg-column>
     <clr-dg-column [clrDgField]="'memory'">Memory (GB)</clr-dg-column>
     <clr-dg-column [clrDgField]="'storage'">Storage (GB)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdCPU'">CPU Hours(vCPU-hr)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdMemory'">Memory Hours (GB-hr)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdStorage'">Storage Hours (GB-hr)</clr-dg-column>
     <clr-dg-column [clrDgField]="'mtdCost'">MTD Cost (US $)</clr-dg-column>
 
     <clr-dg-placeholder>We couldn't find any custom groups!</clr-dg-placeholder>
@@ -14,6 +17,9 @@
       <clr-dg-cell>{{ (group.cpu | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.memory | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.storage | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.mtdCPU | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.mtdMemory | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.mtdStorage | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.mtdCost | number: '1.0-2') || 0 }}</clr-dg-cell>
     </clr-dg-row>
 </clr-datagrid>

--- a/ui/src/app/modules/logical-group/components/logical-group.component.html
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.html
@@ -1,19 +1,19 @@
 <clr-datagrid>
     <clr-dg-column [clrDgField]="'name'">Group Name</clr-dg-column>
     <clr-dg-column [clrDgField]="'podsCount'">Pods</clr-dg-column>
-    <clr-dg-column [clrDgField]="'cpu'">CPU</clr-dg-column>
-    <clr-dg-column [clrDgField]="'memory'">Memory</clr-dg-column>
-    <clr-dg-column [clrDgField]="'storage'">Storage</clr-dg-column>
-    <clr-dg-column [clrDgField]="'mtdCost'">MTD Cost</clr-dg-column>
+    <clr-dg-column [clrDgField]="'cpu'">CPU (vCPU)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'memory'">Memory (GB)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'storage'">Storage (GB)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdCost'">MTD Cost (US $)</clr-dg-column>
 
     <clr-dg-placeholder>We couldn't find any custom groups!</clr-dg-placeholder>
 
     <clr-dg-row *clrDgItems="let group of groups">
       <clr-dg-cell>{{ group.name }}</clr-dg-cell>
       <clr-dg-cell>{{ group.podsCount }}</clr-dg-cell>
-      <clr-dg-cell>{{ group.cpu }}</clr-dg-cell>
-      <clr-dg-cell>{{ group.memory }}</clr-dg-cell>
-      <clr-dg-cell>{{ group.storage }}</clr-dg-cell>
-      <clr-dg-cell>{{ group.mtdCost }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.cpu | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.memory | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.storage | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.mtdCost | number: '1.0-2') || 0 }}</clr-dg-cell>
     </clr-dg-row>
 </clr-datagrid>

--- a/ui/src/app/modules/logical-group/services/logical-group.service.ts
+++ b/ui/src/app/modules/logical-group/services/logical-group.service.ts
@@ -19,7 +19,7 @@ export class LogicalGroupService {
 
         //console.log(_url);
 
-        return this.http.get(_devUrl, {
+        return this.http.get(_url, {
             observe: 'body',
             responseType: 'json'
         });

--- a/ui/src/json/logicalGroup.json
+++ b/ui/src/json/logicalGroup.json
@@ -1,10 +1,55 @@
 [
-    { "name": "Group-3", "podsCount": 4, "cpu": 2, "memory": 7, "storage": 31, "mtdCost": 1.44 },
-    { "name": "Group-1", "podsCount": 2, "cpu": 1, "memory": 3, "storage": 47, "mtdCost": 0.94 },
-    { "name": "Group-4", "podsCount": 6, "cpu": 4, "memory": 10, "storage": 33, "mtdCost": 2.23 },
-    { "name": "Group-5", "podsCount": 3, "cpu": 2, "memory": 2.3, "storage": 64, "mtdCost": 1.04 },
-    { "name": "Group-2", "podsCount": 3, "cpu": 2.5, "memory": 3.1, "storage": 86, "mtdCost": 0.99 },
-    { "name": "Group-8", "podsCount": 2, "cpu": 1.1, "memory": 0.9, "storage": 12, "mtdCost": 0.12 },
-    { "name": "Group-7", "podsCount": 1, "cpu": 0.4, "memory": 0.8, "storage": 10, "mtdCost": 0.16 },
-    { "name": "Group-6", "podsCount": 4, "cpu": 2.6, "memory": 1.7, "storage": 44, "mtdCost": 1.09 }
-]
+    {
+      "name": "vrbc",
+      "podsCount": 882,
+      "mtdCPU": 662.475759,
+      "cpu": 56.9,
+      "mtdCPUCost": 15.899418,
+      "mtdCost": 306.798539,
+      "mtdMemory": 29043.16396,
+      "mtdStorage": 3365.862511,
+      "memory": 1951.792969,
+      "storage": 275,
+      "mtdMemoryCost": 290.43164,
+      "mtdStorageCost": 0.467481
+    },
+    {
+      "name": "tango",
+      "podsCount": 6,
+      "mtdCPU": 223.35569,
+      "mtdMemory": 589.78287,
+      "cpu": 14.55,
+      "memory": 38.406295,
+      "mtdCPUCost": 5.360537,
+      "mtdMemoryCost": 5.897829,
+      "mtdCost": 11.258366
+    },
+    {
+      "name": "symphony",
+      "podsCount": 3,
+      "mtdCPU": 206.529147,
+      "mtdMemory": 812.197643,
+      "mtdStorage": 49.76606,
+      "cpu": 12.45,
+      "memory": 48.960938,
+      "storage": 3,
+      "mtdCPUCost": 4.9567,
+      "mtdMemoryCost": 8.121976,
+      "mtdStorageCost": 0.006912,
+      "mtdCost": 13.085588
+    },
+    {
+      "name": "ops-all",
+      "podsCount": 19,
+      "mtdCPU": 1336.188258,
+      "mtdMemory": 6132.373898,
+      "mtdStorage": 289910.168038,
+      "cpu": 88.75,
+      "memory": 399.859913,
+      "storage": 24380,
+      "mtdCPUCost": 32.068518,
+      "mtdMemoryCost": 61.323739,
+      "mtdStorageCost": 40.265299,
+      "mtdCost": 133.657556
+    }
+  ]


### PR DESCRIPTION
**What this PR does / why we need it**:
API support for custom groups:
- Store custom groups data in dgraph
- add query for retrieving groups and fix number of decimals in UI

**Which issue(s) this PR fixes**:
Fixes #154 