### PR TITLE
Fix number of live pods shown for custom groups

### DIFF
--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -93,6 +93,7 @@ func RetrieveGroupMetricsFromPodUIDs(podsUIDs string) (GroupMetrics, error) {
 			secondsSinceStart as math(cond(stSeconds > ` + secondsSinceMonthStart + `, ` + secondsSinceMonthStart + `, stSeconds))
 			et as endTime
 			isTerminated as count(endTime)
+			isAlive as math(cond(isTerminated == 0, 1, 0))
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
 			pitPodCPU as math(cond(isTerminated == 0, cond(cpuRequestCount > 0, podCpu, 0.0), 0.0))
@@ -124,6 +125,7 @@ func RetrieveGroupMetricsFromPodUIDs(podsUIDs string) (GroupMetrics, error) {
 			cpuCost: sum(val(podCpuCost))
 			memoryCost: sum(val(podMemoryCost))
 			storageCost: sum(val(podStorageCost))
+			livePods: sum(val(isAlive))
 		}
 	}`
 
@@ -180,5 +182,7 @@ func populateMetric(groupMetrics *GroupMetrics, key string, value float64) {
 		groupMetrics.CostMemory = value
 	case "storageCost":
 		groupMetrics.CostStorage = value
+	case "livePods":
+		groupMetrics.PodsCount = int(value)
 	}
 }

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -97,7 +97,7 @@ func getGroupMetrics(group *groups_v1.Group) query.GroupMetrics {
 
 	// if number of occurrences of UID == number of expressions that means the pod satisfies all the expressions(i.e, AND)
 	// get uid-query to retrieve such pods i.e, "uid1, uid2, uid2..."
-	uidQueryForPods, podsCount := getUIDQueryForPods(podUIDsCounter, len(group.Spec.Expressions))
+	uidQueryForPods := getUIDQueryForPods(podUIDsCounter, len(group.Spec.Expressions))
 	log.Debugf("Group: (%v), uidQuery: (%v)", group.Name, uidQueryForPods)
 
 	// get group metrics
@@ -106,7 +106,6 @@ func getGroupMetrics(group *groups_v1.Group) query.GroupMetrics {
 		log.Errorf("Unable to retrieve group metrics. UIDs: (%v)", uidQueryForPods)
 		return query.GroupMetrics{}
 	}
-	groupMetrics.PodsCount = podsCount
 	return groupMetrics
 }
 
@@ -141,10 +140,9 @@ func mapPodUIDsToNumberOfOccurences(podsFromExpressions [][]string) map[string]i
 // returns UIDs for pods that satisfy (number of its occurrences == expressions count) i.e,
 // if number of occurrences of UID == number of expressions that means the pod satisfies all the expressions(-> AND)
 // returns uid-query(i.e, "uid1, uid2, uid2...") that can retrieve desired pods
-func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) (string, int) {
+func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) string {
 	separator := ", "
 	isFirst := true
-	podsCount := 0
 	var uidQueryForPods string
 	for podUID, count := range podsUIDsCounter {
 		if count == expressionsCount {
@@ -154,8 +152,7 @@ func getUIDQueryForPods(podsUIDsCounter map[string]int, expressionsCount int) (s
 				isFirst = false
 			}
 			uidQueryForPods += podUID
-			podsCount++
 		}
 	}
-	return uidQueryForPods, podsCount
+	return uidQueryForPods
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes number of pods shown for custom groups in UI. With this PR purser shows number of live pods in UI.

**Which issue(s) this PR fixes**:
Fixes #160 

**Special notes for your reviewer**:
Tested on local setup
