### PR TITLE
Bump up the value for the resource limits and requests for purser UI

### DIFF
--- a/cluster/purser-setup.yaml
+++ b/cluster/purser-setup.yaml
@@ -98,10 +98,10 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 250Mi
-            cpu: 100m
+            memory: 1000Mi
+            cpu: 300m
           requests:
-            memory: 250Mi
-            cpu: 100m
+            memory: 1000Mi
+            cpu: 300m
         ports:
         - containerPort: 4200


### PR DESCRIPTION
**What this PR does / why we need it**:

The current resource limits and requests value is insufficient for handling the purser UI deployment.
The values should be bumped up to enable UI to render properly.

**Which issue(s) this PR fixes** 
Fixes #163 

