### PR TITLE
Populate price for unit resource

### DIFF
--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -112,7 +112,8 @@ func startCronJobForPopulatingRateCard() {
 	cloud.PopulateRateCard()
 
 	c := cron.New()
-	err := c.AddFunc("@every 7d", cloud.PopulateRateCard)
+
+	err := c.AddFunc("@every 168h", cloud.PopulateRateCard)
 	if err != nil {
 		log.Error(err)
 	}

--- a/pkg/controller/dgraph/models/rateCard.go
+++ b/pkg/controller/dgraph/models/rateCard.go
@@ -51,6 +51,8 @@ type NodePrice struct {
 	InstanceFamily  string  `json:"instanceFamily,omitempty"`
 	OperatingSystem string  `json:"operatingSystem,omitempty"`
 	Price           float64 `json:"price,omitempty"`
+	PricePerCPU     string  `json:"cpuPrice,omitempty"`
+	PricePerMemory  string  `json:"memoryPrice,omitempty"`
 }
 
 // StoragePrice structure
@@ -61,6 +63,7 @@ type StoragePrice struct {
 	VolumeType     string  `json:"volumeType,omitempty"`
 	UsageType      string  `json:"usageType,omitempty"`
 	Price          float64 `json:"price,omitempty"`
+	PricePerGB     string  `json:"pricePerGB,omitempty"`
 }
 
 // StoreRateCard given a cloudProvider and region it gets rate card and stores(create/update) in dgraph

--- a/pkg/pricing/aws/aws.go
+++ b/pkg/pricing/aws/aws.go
@@ -66,6 +66,8 @@ type ProductAttributes struct {
 	PreInstalledSW  string
 	VolumeType      string
 	UsageType       string
+	CPU             string
+	Memory          string
 }
 
 // GetAWSPricing function details

--- a/pkg/pricing/aws/aws.go
+++ b/pkg/pricing/aws/aws.go
@@ -66,7 +66,7 @@ type ProductAttributes struct {
 	PreInstalledSW  string
 	VolumeType      string
 	UsageType       string
-	CPU             string
+	Vcpu            string
 	Memory          string
 }
 

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -165,7 +165,7 @@ func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, s
 		// memWithUnits format: "3,126 GiB"
 		mem, err := strconv.ParseFloat(strings.Join(strings.Split(strings.Split(memWithUnits, " GiB")[0], ","), ""), 64)
 		if err == nil {
-			pricePerGB = strconv.FormatFloat(priceSplitRatio*priceInFloat64/mem, 'f', 11, 64)
+			pricePerGB = strconv.FormatFloat((1-priceSplitRatio)*priceInFloat64/mem, 'f', 11, 64)
 		}
 	}
 	return pricePerCPU, pricePerGB

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -105,7 +105,7 @@ func getResourcePrice(product Product, planList PlanList) (float64, string) {
 func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, string) {
 	pricePerCPU := defaultCPUCostPerCPUPerHour
 	pricePerGB := defaultMemCostPerGBPerHour
-	if priceInFloat64 != priceError {
+	if priceInFloat64 != priceError && priceInFloat64 != 0 {
 		cpu, err := strconv.ParseFloat(product.Attributes.Vcpu, 64)
 		if err == nil {
 			pricePerCPU = strconv.FormatFloat(priceSplitRatio*priceInFloat64/cpu, 'f', 11, 64)

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -79,7 +79,6 @@ func getResourcePricesFromAWSPricing(awsPricing *Pricing) ([]*models.NodePrice, 
 		case storageInstance:
 			storagePrices = updateStorageInstancePrices(product, priceInFloat64, unit, storagePrices)
 		}
-
 	}
 	return nodePrices, storagePrices
 }
@@ -154,6 +153,8 @@ func updateStorageInstancePrices(product Product, priceInFloat64 float64, unit s
 func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, string) {
 	pricePerCPU := defaultCPUCostPerCPUPerHour
 	pricePerGB := defaultMemCostPerGBPerHour
+
+	// priceInFloat64 should be greater than 0 otherwise this function returns default pricing
 	if priceInFloat64 != priceError && priceInFloat64 != 0 {
 		cpu, err := strconv.ParseFloat(product.Attributes.Vcpu, 64)
 		if err == nil {

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -114,7 +114,7 @@ func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, s
 		memWithUnits := product.Attributes.Memory
 		mem, err := strconv.ParseFloat(strings.Join(strings.Split(strings.Split(memWithUnits, " GiB")[0], ","), ""), 64)
 		if err == nil {
-			pricePerCPU = strconv.FormatFloat(priceSplitRatio*priceInFloat64/mem, 'f', 11, 64)
+			pricePerGB = strconv.FormatFloat(priceSplitRatio*priceInFloat64/mem, 'f', 11, 64)
 		}
 	}
 	return pricePerCPU, pricePerGB

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -112,6 +112,7 @@ func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, s
 		}
 
 		memWithUnits := product.Attributes.Memory
+		// memWithUnits format: "3,126 GiB"
 		mem, err := strconv.ParseFloat(strings.Join(strings.Split(strings.Split(memWithUnits, " GiB")[0], ","), ""), 64)
 		if err == nil {
 			pricePerGB = strconv.FormatFloat(priceSplitRatio*priceInFloat64/mem, 'f', 11, 64)

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -112,7 +112,7 @@ func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, s
 		}
 
 		memWithUnits := product.Attributes.Memory
-		mem, err := strconv.ParseFloat(strings.Split(memWithUnits, " GiB")[0], 64)
+		mem, err := strconv.ParseFloat(strings.Join(strings.Split(strings.Split(memWithUnits, " GiB")[0], ","), ""), 64)
 		if err == nil {
 			pricePerCPU = strconv.FormatFloat(priceSplitRatio*priceInFloat64/mem, 'f', 11, 64)
 		}

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -106,7 +106,7 @@ func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, s
 	pricePerCPU := defaultCPUCostPerCPUPerHour
 	pricePerGB := defaultMemCostPerGBPerHour
 	if priceInFloat64 != priceError {
-		cpu, err := strconv.ParseFloat(product.Attributes.CPU, 64)
+		cpu, err := strconv.ParseFloat(product.Attributes.Vcpu, 64)
 		if err == nil {
 			pricePerCPU = strconv.FormatFloat(priceSplitRatio*priceInFloat64/cpu, 'f', 11, 64)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
- At present, Purser populates NodePrices and StoragePrices. For cost evaluation at pod level we need price for unit cpu, price for unit memory, price for unit storage
- This also fixes wrong time period for rate card cron job

**Note:** 
- Assumption that split ratio is 1:1 for cpu:memory
- Some instance prices are shown as 0, which isn't correct as price also depends on insalled software etc. In such cases price is set to default price.

**Which issue(s) this PR fixes** :
Fixes a task in #174 