### PR TITLE
Node instance costing

### DIFF
--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -106,7 +106,7 @@ func runGroupUpdate() {
 }
 
 func startCronJobForPopulatingRateCard() {
-	cloud := &pricing.Cloud{}
+	cloud := &pricing.Cloud{Kubeclient: conf.Kubeclient}
 	// find cloud provider and region
 	cloud.CloudProvider, cloud.Region = pricing.GetClusterProviderAndRegion()
 	cloud.PopulateRateCard()

--- a/pkg/controller/dgraph/models/constants.go
+++ b/pkg/controller/dgraph/models/constants.go
@@ -1,0 +1,8 @@
+package models
+
+// Cost constants
+const (
+	DefaultCPUCostPerCPUPerHour    = "0.024"
+	DefaultMemCostPerGBPerHour     = "0.01"
+	DefaultStorageCostPerGBPerHour = "0.00013888888"
+)

--- a/pkg/controller/dgraph/models/constants.go
+++ b/pkg/controller/dgraph/models/constants.go
@@ -1,8 +1,19 @@
 package models
 
-// Cost constants
+// Cost and other cloud constants
 const (
+	// Cost constants
 	DefaultCPUCostPerCPUPerHour    = "0.024"
 	DefaultMemCostPerGBPerHour     = "0.01"
 	DefaultStorageCostPerGBPerHour = "0.00013888888"
+	DefaultStorageCostInFloat64    = 0.00013888888
+
+	// Cloud provider constants
+	AWS = "aws"
+
+	// Time constants
+	HoursInMonth = 720
+
+	// Other constants
+	PriceError = -1.0
 )

--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -50,6 +50,8 @@ type Node struct {
 	Type           string  `json:"type,omitempty"`
 	InstanceType   string  `json:"instanceType,omitempty"`
 	OS             string  `json:"os,omitempty"`
+	CPUPrice       string  `json:"cpuPrice,omitempty"`
+	MemoryPrice    string  `json:"memoryPrice,omitempty"`
 }
 
 func createNodeObject(node api_v1.Node) Node {
@@ -106,6 +108,8 @@ func StoreNode(node api_v1.Node) (string, error) {
 	if uid != "" {
 		newNode.UID = uid
 	}
+
+	newNode.CPUPrice, newNode.MemoryPrice = getPricePerUnitResourceFromNodePrice(newNode)
 	assigned, err := dgraph.MutateNode(newNode, dgraph.CREATE)
 	if err != nil {
 		return "", err

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -60,6 +60,8 @@ type Pod struct {
 	Type           string                   `json:"type,omitempty"`
 	Cid            []Service                `json:"cid,omitempty"`
 	Labels         []*Label                 `json:"label,omitempty"`
+	CPUPrice       string                   `json:"cpuPrice,omitempty"`
+	MemoryPrice    string                   `json:"memoryPrice,omitempty"`
 }
 
 // Metrics ...
@@ -129,6 +131,9 @@ func StorePod(k8sPod api_v1.Pod) error {
 		}
 		populatePodLabels(&pod, k8sPod.Labels)
 	}
+
+	// store/update CPUPrice, MemoryPrice
+	pod.CPUPrice, pod.MemoryPrice = getPerUnitResourcePriceForNode(k8sPod.Spec.NodeName)
 
 	_, err := dgraph.MutateNode(pod, dgraph.UPDATE)
 	return err

--- a/pkg/controller/dgraph/models/query/cluster.go
+++ b/pkg/controller/dgraph/models/query/cluster.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"
@@ -81,9 +83,11 @@ func RetrieveClusterMetrics(view string) JSONDataWrapper {
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-				cpuCost: math(cpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: math(memory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: math(storage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+				pricePerCPU as cpuPrice
+				pricePerMemory as memoryPrice
+				cpuCost: math(cpu * durationInHours * pricePerCPU)
+				memoryCost: math(memory * durationInHours * pricePerMemory)
+				storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 		}`
 	} else {
@@ -100,9 +104,11 @@ func RetrieveClusterMetrics(view string) JSONDataWrapper {
 					isTerminated as count(endTime)
 					secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 					durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-					namespacePodCpuCost as math(namespacePodCpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					namespacePodMemoryCost as math(namespacePodMem * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-					namespacePodStorageCost as math(namespacePvcStorage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					pricePerCPU as cpuPrice
+					pricePerMemory as memoryPrice
+					namespacePodCpuCost as math(namespacePodCpu * durationInHours * pricePerCPU)
+					namespacePodMemoryCost as math(namespacePodMem * durationInHours * pricePerMemory)
+					namespacePodStorageCost as math(namespacePvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 				}
 				namespaceCpu as sum(val(namespacePodCpu))
 				namespaceMem as sum(val(namespacePodMem))

--- a/pkg/controller/dgraph/models/query/container.go
+++ b/pkg/controller/dgraph/models/query/container.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -63,8 +65,8 @@ func RetrieveContainerMetrics(name string) JSONDataWrapper {
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-			cpuCost: math(cpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-			memoryCost: math(memory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
+			cpuCost: math(cpu * durationInHours * ` + models.DefaultCPUCostPerCPUPerHour + `)
+			memoryCost: math(memory * durationInHours * ` + models.DefaultMemCostPerGBPerHour + `)
 		}
 	}`
 	return getJSONDataFromQuery(query)

--- a/pkg/controller/dgraph/models/query/daemonset.go
+++ b/pkg/controller/dgraph/models/query/daemonset.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -67,9 +69,11 @@ func RetrieveDaemonsetMetrics(name string) JSONDataWrapper {
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-				cpuCost: podCpuCost as math(podCpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: podMemCost as math(podMemory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+				pricePerCPU as cpuPrice
+				pricePerMemory as memoryPrice
+				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)
+				memoryCost: podMemCost as math(podMemory * durationInHours * pricePerMemory)
+				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			cpu: sum(val(podCpu))
 			memory: sum(val(podMemory))

--- a/pkg/controller/dgraph/models/query/deployment.go
+++ b/pkg/controller/dgraph/models/query/deployment.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -64,9 +66,11 @@ func RetrieveDeploymentMetrics(name string) JSONDataWrapper {
 					replicasetPodIsTerminated as count(endTime)
 					replicasetPodSecondsSinceEnd as math(cond(replicasetPodIsTerminated == 0, 0.0, since(replicasetPodET)))
 					replicasetPodDurationInHours as math((replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600)
-					replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					replicasetPodMemoryCost as math(replicasetPodMemory * replicasetPodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-					replicasetPvcStorageCost as math(replicasetPvcStorage * replicasetPodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					pricePerCPU as cpuPrice
+					pricePerMemory as memoryPrice
+					replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * pricePerCPU)
+					replicasetPodMemoryCost as math(replicasetPodMemory * replicasetPodDurationInHours * pricePerMemory)
+					replicasetPvcStorageCost as math(replicasetPvcStorage * replicasetPodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 				}
 				deploymentReplicasetCpu as sum(val(replicasetPodCpu))
 				deploymentReplicasetMemory as sum(val(replicasetPodMemory))

--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -106,9 +106,11 @@ func RetrieveGroupMetricsFromPodUIDs(podsUIDs string) (GroupMetrics, error) {
 			mtdPvcStorage as math(pvcStorage * durationInHours)
 			mtdPodCPULimit as math(podCpuLimit * durationInHours)
 			mtdPodMemoryLimit as math(podMemoryLimit * durationInHours)
-			podCpuCost as math(mtdPodCPU * ` + defaultCPUCostPerCPUPerHour + `)
-			podMemoryCost as math(mtdPodMemory * ` + defaultMemCostPerGBPerHour + `)
-			podStorageCost as math(mtdPvcStorage * ` + defaultStorageCostPerGBPerHour + `)
+			pricePerCPU as cpuPrice
+			pricePerMemory as memoryPrice
+			podCpuCost as math(mtdPodCPU * pricePerCPU)
+			podMemoryCost as math(mtdPodMemory * pricePerMemory)
+			podStorageCost as math(mtdPvcStorage * ` + models.DefaultStorageCostPerGBPerHour + `)
 		}
 		
 		group() {

--- a/pkg/controller/dgraph/models/query/job.go
+++ b/pkg/controller/dgraph/models/query/job.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -67,9 +69,11 @@ func RetrieveJobMetrics(name string) JSONDataWrapper {
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-				cpuCost: podCpuCost as math(podCpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: podMemCost as math(podMemory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+				pricePerCPU as cpuPrice
+				pricePerMemory as memoryPrice
+				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)
+				memoryCost: podMemCost as math(podMemory * durationInHours * pricePerMemory)
+				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			cpu: sum(val(podCpu))
 			memory: sum(val(podMemory))

--- a/pkg/controller/dgraph/models/query/namespace.go
+++ b/pkg/controller/dgraph/models/query/namespace.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph"
 	"github.com/vmware/purser/pkg/controller/utils"
@@ -72,9 +74,11 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 						replicasetPodIsTerminated as count(endTime)
 						replicasetPodSecondsSinceEnd as math(cond(replicasetPodIsTerminated == 0, 0.0, since(replicasetPodET)))
 						replicasetPodDurationInHours as math((replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600)
-						replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-						replicasetPodMemoryCost as math(replicasetPodMemory * replicasetPodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-						replicasetPvcStorageCost as math(replicasetPvcStorage * replicasetPodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+						replicasetPricePerCPU as cpuPrice
+						replicasetPricePerMemory as memoryPrice
+						replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * replicasetPricePerCPU)
+						replicasetPodMemoryCost as math(replicasetPodMemory * replicasetPodDurationInHours * replicasetPricePerMemory)
+						replicasetPvcStorageCost as math(replicasetPvcStorage * replicasetPodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			        }
 					deploymentReplicasetCpu as sum(val(replicasetPodCpu))
 			        deploymentReplicasetMemory as sum(val(replicasetPodMemory))
@@ -96,9 +100,11 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					statefulsetPodIsTerminated as count(endTime)
 					statefulsetPodSecondsSinceEnd as math(cond(statefulsetPodIsTerminated == 0, 0.0, since(statefulsetPodET)))
 					statefulsetPodDurationInHours as math((statefulsetPodSecondsSinceStart - statefulsetPodSecondsSinceEnd) / 3600)
-					statefulsetPodCpuCost as math(statefulsetPodCpu * statefulsetPodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					statefulsetPodMemoryCost as math(statefulsetPodMemory * statefulsetPodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-					statefulsetPvcStorageCost as math(statefulsetPvcStorage * statefulsetPodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					statefulsetPricePerCPU as cpuPrice
+					statefulsetPricePerMemory as memoryPrice
+					statefulsetPodCpuCost as math(statefulsetPodCpu * statefulsetPodDurationInHours * statefulsetPricePerCPU)
+					statefulsetPodMemoryCost as math(statefulsetPodMemory * statefulsetPodDurationInHours * statefulsetPricePerMemory)
+					statefulsetPvcStorageCost as math(statefulsetPvcStorage * statefulsetPodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
                 }
 				~job @filter(has(isPod)) {
                     name
@@ -113,9 +119,11 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					jobPodIsTerminated as count(endTime)
 					jobPodSecondsSinceEnd as math(cond(jobPodIsTerminated == 0, 0.0, since(jobPodET)))
 					jobPodDurationInHours as math((jobPodSecondsSinceStart - jobPodSecondsSinceEnd) / 3600)
-					jobPodCpuCost as math(jobPodCpu * jobPodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					jobPodMemoryCost as math(jobPodMemory * jobPodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-					jobPvcStorageCost as math(jobPvcStorage * jobPodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					jobPricePerCPU as cpuPrice
+					jobPricePerMemory as memoryPrice
+					jobPodCpuCost as math(jobPodCpu * jobPodDurationInHours * jobPricePerCPU)
+					jobPodMemoryCost as math(jobPodMemory * jobPodDurationInHours * jobPricePerMemory)
+					jobPvcStorageCost as math(jobPvcStorage * jobPodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
                 }
 				~daemonset @filter(has(isPod)) {
                     name
@@ -130,9 +138,11 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					daemonsetPodIsTerminated as count(endTime)
 					daemonsetPodSecondsSinceEnd as math(cond(daemonsetPodIsTerminated == 0, 0.0, since(daemonsetPodET)))
 					daemonsetPodDurationInHours as math((daemonsetPodSecondsSinceStart - daemonsetPodSecondsSinceEnd) / 3600)
-					daemonsetPodCpuCost as math(daemonsetPodCpu * daemonsetPodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					daemonsetPodMemoryCost as math(daemonsetPodMemory * daemonsetPodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-					daemonsetPvcStorageCost as math(daemonsetPvcStorage * daemonsetPodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					daemonsetPricePerCPU as cpuPrice
+					daemonsetPricePerMemory as memoryPrice
+					daemonsetPodCpuCost as math(daemonsetPodCpu * daemonsetPodDurationInHours * daemonsetPricePerCPU)
+					daemonsetPodMemoryCost as math(daemonsetPodMemory * daemonsetPodDurationInHours * daemonsetPricePerMemory)
+					daemonsetPvcStorageCost as math(daemonsetPvcStorage * daemonsetPodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
                 }
 				~replicaset @filter(has(isPod)) {
                     name
@@ -147,9 +157,11 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					replicasetSimplePodIsTerminated as count(endTime)
 					replicasetSimplePodSecondsSinceEnd as math(cond(replicasetSimplePodIsTerminated == 0, 0.0, since(replicasetSimplePodET)))
 					replicasetSimplePodDurationInHours as math((replicasetSimplePodSecondsSinceStart - replicasetSimplePodSecondsSinceEnd) / 3600)
-					replicasetSimplePodCpuCost as math(replicasetSimplePodCpu * replicasetSimplePodDurationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-					replicasetSimplePodMemoryCost as math(replicasetSimplePodMemory * replicasetSimplePodDurationInHours * ` + defaultMemCostPerGBPerHour + `)
-					replicasetSimplePvcStorageCost as math(replicasetSimplePvcStorage * replicasetSimplePodDurationInHours * ` + defaultStorageCostPerGBPerHour + `)
+					replicasetSimplePricePerCPU as cpuPrice
+					replicasetSimplePricePerMemory as memoryPrice
+					replicasetSimplePodCpuCost as math(replicasetSimplePodCpu * replicasetSimplePodDurationInHours * replicasetSimplePricePerCPU)
+					replicasetSimplePodMemoryCost as math(replicasetSimplePodMemory * replicasetSimplePodDurationInHours * replicasetSimplePricePerMemory)
+					replicasetSimplePvcStorageCost as math(replicasetSimplePvcStorage * replicasetSimplePodDurationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
                 }
 				sumReplicasetSimplePodCpu as sum(val(replicasetSimplePodCpu))
 				sumDaemonsetPodCpu as sum(val(daemonsetPodCpu))

--- a/pkg/controller/dgraph/models/query/node.go
+++ b/pkg/controller/dgraph/models/query/node.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -69,9 +71,11 @@ func RetrieveNodeMetrics(name string) JSONDataWrapper {
 				isTerminatedChild as count(endTime)
 				secondsSinceEndChild as math(cond(isTerminatedChild == 0, 0.0, since(etChild)))
 				durationInHoursChild as math((secondsSinceStartChild - secondsSinceEndChild) / 3600)
-				cpuCost: math(podCpu * durationInHoursChild * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: math(podMemory * durationInHoursChild * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: math(pvcStorage * durationInHoursChild * ` + defaultStorageCostPerGBPerHour + `)
+				podPricePerCPU as cpuPrice
+				podPricePerMemory as memoryPrice
+				cpuCost: math(podCpu * durationInHoursChild * podPricePerCPU)
+				memoryCost: math(podMemory * durationInHoursChild * podPricePerMemory)
+				storageCost: math(pvcStorage * durationInHoursChild * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			cpu: cpu as cpuCapacity
 			memory: memory as memoryCapacity
@@ -83,9 +87,11 @@ func RetrieveNodeMetrics(name string) JSONDataWrapper {
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-			cpuCost: math(cpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-			memoryCost: math(memory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-			storageCost: math(storage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+			pricePerCPU as cpuPrice
+			pricePerMemory as memoryPrice
+			cpuCost: math(cpu * durationInHours * pricePerCPU)
+			memoryCost: math(memory * durationInHours * pricePerMemory)
+			storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 		}
 	}`
 	return getJSONDataFromQuery(query)

--- a/pkg/controller/dgraph/models/query/pv.go
+++ b/pkg/controller/dgraph/models/query/pv.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -67,7 +69,7 @@ func RetrievePVMetrics(name string) JSONDataWrapper {
 				isTerminatedChild as count(endTime)
 				secondsSinceEndChild as math(cond(isTerminatedChild == 0, 0.0, since(etChild)))
 				durationInHoursChild as math((secondsSinceStartChild - secondsSinceEndChild) / 3600)
-				storageCost: math(pvcStorage * durationInHoursChild * ` + defaultMemCostPerGBPerHour + `)
+				storageCost: math(pvcStorage * durationInHoursChild * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			storage: storage as storageCapacity
 			st as startTime
@@ -77,7 +79,7 @@ func RetrievePVMetrics(name string) JSONDataWrapper {
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-			storageCost: math(storage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+			storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
         }
     }`
 	return getJSONDataFromQuery(query)

--- a/pkg/controller/dgraph/models/query/pvc.go
+++ b/pkg/controller/dgraph/models/query/pvc.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -44,7 +46,7 @@ func RetrievePVCMetrics(name string) JSONDataWrapper {
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-			storageCost: math(storage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+			storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
         }
     }`
 	return getJSONDataFromQuery(query)

--- a/pkg/controller/dgraph/models/query/replicaset.go
+++ b/pkg/controller/dgraph/models/query/replicaset.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -67,9 +69,11 @@ func RetrieveReplicasetMetrics(name string) JSONDataWrapper {
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-				cpuCost: podCpuCost as math(podCpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: podMemCost as math(podMemory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+				pricePerCPU as cpuPrice
+				pricePerMemory as memoryPrice
+				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)
+				memoryCost: podMemCost as math(podMemory * durationInHours * pricePerMemory)
+				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			cpu: sum(val(podCpu))
 			memory: sum(val(podMemory))

--- a/pkg/controller/dgraph/models/query/statefulset.go
+++ b/pkg/controller/dgraph/models/query/statefulset.go
@@ -20,6 +20,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/utils"
 )
@@ -67,9 +69,11 @@ func RetrieveStatefulsetMetrics(name string) JSONDataWrapper {
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
 				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
-				cpuCost: podCpuCost as math(podCpu * durationInHours * ` + defaultCPUCostPerCPUPerHour + `)
-				memoryCost: podMemCost as math(podMemory * durationInHours * ` + defaultMemCostPerGBPerHour + `)
-				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + defaultStorageCostPerGBPerHour + `)
+				pricePerCPU as cpuPrice
+				pricePerMemory as memoryPrice
+				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)
+				memoryCost: podMemCost as math(podMemory * durationInHours * pricePerMemory)
+				storageCost: pvcStorageCost as math(pvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			cpu: sum(val(podCpu))
 			memory: sum(val(podMemory))

--- a/pkg/controller/dgraph/models/query/types.go
+++ b/pkg/controller/dgraph/models/query/types.go
@@ -28,13 +28,6 @@ const (
 	False    = "false"
 )
 
-// Cost constants
-const (
-	defaultCPUCostPerCPUPerHour    = "0.024"
-	defaultMemCostPerGBPerHour     = "0.01"
-	defaultStorageCostPerGBPerHour = "0.00013888888"
-)
-
 // Children structure
 type Children struct {
 	Name        string  `json:"name,omitempty"`

--- a/pkg/controller/dgraph/models/rateCard.go
+++ b/pkg/controller/dgraph/models/rateCard.go
@@ -30,8 +30,6 @@ const (
 	IsNodePrice    = "isNodePrice"
 	IsStoragePrice = "isStoragePrice"
 	RateCardXID    = "purser-rateCard"
-
-	AWS = "aws"
 )
 
 // RateCard structure

--- a/pkg/controller/dgraph/models/rateCard.go
+++ b/pkg/controller/dgraph/models/rateCard.go
@@ -180,22 +180,18 @@ func retrieveNodePrice(xid string) (*NodePrice, error) {
 
 // getPerUnitResourcePriceForNode returns price per cpu and price per memory
 func getPerUnitResourcePriceForNode(nodeName string) (string, string) {
-	cpuPrice := DefaultCPUCostPerCPUPerHour
-	memoryPrice := DefaultMemCostPerGBPerHour
 	node, err := retrieveNode(nodeName)
 	if err == nil {
 		return getPricePerUnitResourceFromNodePrice(*node)
 	}
-	return cpuPrice, memoryPrice
+	return DefaultCPUCostPerCPUPerHour, DefaultMemCostPerGBPerHour
 }
 
 func getPricePerUnitResourceFromNodePrice(node Node) (string, string) {
-	cpuPrice := DefaultCPUCostPerCPUPerHour
-	memoryPrice := DefaultMemCostPerGBPerHour
 	nodePriceXID := node.InstanceType + "-" + node.OS
 	nodePrice, err := retrieveNodePrice(nodePriceXID)
 	if err == nil {
-		cpuPrice, memoryPrice = nodePrice.PricePerCPU, nodePrice.PricePerMemory
+		return nodePrice.PricePerCPU, nodePrice.PricePerMemory
 	}
-	return cpuPrice, memoryPrice
+	return DefaultCPUCostPerCPUPerHour, DefaultMemCostPerGBPerHour
 }

--- a/pkg/controller/utils/k8sUtils.go
+++ b/pkg/controller/utils/k8sUtils.go
@@ -45,6 +45,16 @@ func RetrievePodList(client *kubernetes.Clientset, options metav1.ListOptions) *
 	return pods
 }
 
+// RetrieveNodeList returns list of nodes
+func RetrieveNodeList(client *kubernetes.Clientset, options metav1.ListOptions) *corev1.NodeList {
+	nodes, err := client.CoreV1().Nodes().List(options)
+	if err != nil {
+		log.Errorf("failed to retrieve nodes: %v", err)
+		return nil
+	}
+	return nodes
+}
+
 // RetrieveServiceList returns list of services in the given namespace.
 func RetrieveServiceList(client *kubernetes.Clientset, options metav1.ListOptions) *corev1.ServiceList {
 	services, err := client.CoreV1().Services(metav1.NamespaceAll).List(options)

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -103,7 +103,7 @@ func updateComputeInstancePrices(product Product, priceInFloat64 float64, duplic
 	key := product.Sku + product.Attributes.InstanceType + product.Attributes.OperatingSystem
 	if _, isPresent := duplicateComputeInstanceChecker[key]; !isPresent && product.Attributes.PreInstalledSW == na {
 		// Unit of Compute price USD-perHour
-		productXID := product.Attributes.InstanceType + deliminator + product.Attributes.InstanceFamily + deliminator + product.Attributes.OperatingSystem
+		productXID := product.Attributes.InstanceType + deliminator + product.Attributes.OperatingSystem
 		pricePerCPU, pricePerGB := getPriceForUnitResource(product, priceInFloat64)
 		nodePrice := &models.NodePrice{
 			ID:              dgraph.ID{Xid: productXID},

--- a/pkg/pricing/aws/convert.go
+++ b/pkg/pricing/aws/convert.go
@@ -26,21 +26,16 @@ import (
 	"github.com/vmware/purser/pkg/controller/dgraph/models"
 )
 
+// AWS specific constants
 const (
 	na              = "NA"
-	aws             = "aws"
 	gbMonth         = "GB-Mo"
 	deliminator     = "-"
 	storageInstance = "Storage"
 	computeInstance = "Compute Instance"
-	priceError      = -1.0
-	hoursInMonth    = 720
 
 	// TODO: Determine priceSplitRatio according to instance type i.e, compute optimized or memory optimized etc
-	priceSplitRatio             = 0.5
-	defaultCPUCostPerCPUPerHour = "0.024"
-	defaultMemCostPerGBPerHour  = "0.01"
-	defaultStorageCostInFloat64 = 0.00013888888
+	priceSplitRatio = 0.5
 )
 
 // GetRateCardForAWS takes region as input and returns RateCard and error if any
@@ -57,7 +52,7 @@ func convertAWSPricingToPurserRateCard(region string, awsPricing *Pricing) *mode
 	return &models.RateCard{
 		ID:            dgraph.ID{Xid: models.RateCardXID},
 		IsRateCard:    true,
-		CloudProvider: aws,
+		CloudProvider: models.AWS,
 		Region:        region,
 		NodePrices:    nodePrices,
 		StoragePrices: storagePrices,
@@ -90,13 +85,13 @@ func getResourcePrice(product Product, planList PlanList) (float64, string) {
 				priceInFloat64, err := strconv.ParseFloat(pricePerUnit, 64)
 				if err != nil {
 					logrus.Errorf("unable to parse string: %s to float. err: %v", pricePerUnit, err)
-					return priceError, "" // negative price means error
+					return models.PriceError, "" // negative price means error
 				}
 				return priceInFloat64, pricingData.Unit
 			}
 		}
 	}
-	return priceError, ""
+	return models.PriceError, ""
 }
 
 func updateComputeInstancePrices(product Product, priceInFloat64 float64, duplicateComputeInstanceChecker map[string]bool, nodePrices []*models.NodePrice) []*models.NodePrice {
@@ -126,11 +121,11 @@ func updateComputeInstancePrices(product Product, priceInFloat64 float64, duplic
 }
 
 func updateStorageInstancePrices(product Product, priceInFloat64 float64, unit string, storagePrices []*models.StoragePrice) []*models.StoragePrice {
-	if priceInFloat64 == priceError {
-		priceInFloat64 = defaultStorageCostInFloat64
+	if priceInFloat64 == models.PriceError {
+		priceInFloat64 = models.DefaultStorageCostInFloat64
 	} else if unit == gbMonth {
 		// convert to GBHour
-		priceInFloat64 = priceInFloat64 / hoursInMonth
+		priceInFloat64 = priceInFloat64 / models.HoursInMonth
 	}
 
 	productXID := product.Attributes.VolumeType + deliminator + product.Attributes.UsageType
@@ -151,11 +146,11 @@ func updateStorageInstancePrices(product Product, priceInFloat64 float64, unit s
 }
 
 func getPriceForUnitResource(product Product, priceInFloat64 float64) (string, string) {
-	pricePerCPU := defaultCPUCostPerCPUPerHour
-	pricePerGB := defaultMemCostPerGBPerHour
+	pricePerCPU := models.DefaultCPUCostPerCPUPerHour
+	pricePerGB := models.DefaultMemCostPerGBPerHour
 
 	// priceInFloat64 should be greater than 0 otherwise this function returns default pricing
-	if priceInFloat64 != priceError && priceInFloat64 != 0 {
+	if priceInFloat64 != models.PriceError && priceInFloat64 != 0 {
 		cpu, err := strconv.ParseFloat(product.Attributes.Vcpu, 64)
 		if err == nil {
 			pricePerCPU = strconv.FormatFloat(priceSplitRatio*priceInFloat64/cpu, 'f', 11, 64)

--- a/pkg/pricing/cloud.go
+++ b/pkg/pricing/cloud.go
@@ -25,6 +25,10 @@ import (
 // constants for cloud provider pricing
 const (
 	AWS = "aws"
+
+	defaultCPUCostPerCPUPerHour    = "0.024"
+	defaultMemCostPerGBPerHour     = "0.01"
+	defaultStorageCostPerGBPerHour = "0.00013888888"
 )
 
 // Cloud structure used for pricing
@@ -36,7 +40,9 @@ type Cloud struct {
 // GetClusterProviderAndRegion returns cluster provider(ex: aws) and region(ex: us-east-1)
 func GetClusterProviderAndRegion() (string, string) {
 	// TODO: https://github.com/vmware/purser/issues/143
-	return AWS, "us-east-1"
+	cloudProvider := AWS
+	region := "us-east-1"
+	return cloudProvider, region
 }
 
 // PopulateRateCard given a cloud (cloudProvider and region) it populates corresponding rate card in dgraph


### PR DESCRIPTION
**What this PR does / why we need it**:
- Store price per cpu, price per memory in nodes and pods
- Update price per cpu, price per memory for nodes and pods whenever rate card gets updated
- Cost computation is based on price corresponding to node type
- Refactor: Move all general constants to `models` package

**Which issue(s) this PR fixes**:
Fixes #176 