### PR TITLE
Handle re-sync for pods, containers

### DIFF
--- a/cmd/controller/purserctrl.go
+++ b/cmd/controller/purserctrl.go
@@ -64,6 +64,7 @@ func main() {
 	}
 	go startCronJobForUpdatingCustomGroups()
 	go startCronJobForPopulatingRateCard()
+	go startCronJobForSyncingCluster()
 	controller.Start(&conf)
 }
 
@@ -118,4 +119,23 @@ func startCronJobForPopulatingRateCard() {
 		log.Error(err)
 	}
 	c.Start()
+}
+
+func startCronJobForSyncingCluster() {
+	runSync()
+
+	// reSync again after some time
+	time.Sleep(time.Minute * 2)
+	runSync()
+
+	c := cron.New()
+	err := c.AddFunc("@every 24h", runSync)
+	if err != nil {
+		log.Error(err)
+	}
+	c.Start()
+}
+
+func runSync() {
+	eventprocessor.SyncCluster(conf.Kubeclient)
 }

--- a/pkg/controller/dgraph/models/pvc.go
+++ b/pkg/controller/dgraph/models/pvc.go
@@ -20,6 +20,8 @@ package models
 import (
 	"time"
 
+	"github.com/Sirupsen/logrus"
+
 	"log"
 
 	"github.com/vmware/purser/pkg/controller/dgraph"
@@ -81,6 +83,11 @@ func StorePersistentVolumeClaim(pvc api_v1.PersistentVolumeClaim) (string, error
 	newPvc := createPvcObject(pvc)
 	if uid != "" {
 		newPvc.UID = uid
+		oldPvc := PersistentVolumeClaim{ID: dgraph.ID{UID: uid}, EndTime: ""}
+		_, err := dgraph.MutateNode(oldPvc, dgraph.DELETE)
+		if err != nil {
+			logrus.Errorf("unable to delete end time for pvc: %s, err: %v", xid, err)
+		}
 	}
 	assigned, err := dgraph.MutateNode(newPvc, dgraph.CREATE)
 	if err != nil {

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -27,6 +27,28 @@ import (
 	"github.com/vmware/purser/pkg/controller/utils"
 )
 
+// RetrieveAllLivePods will return all pods without endTime in dgraph. Error is returned if any
+// failure is encountered in the process.
+func RetrieveAllLivePods() []models.Pod {
+	query := `query {
+		pods(func: has(isPod)) @filter(NOT has(endTime)) {
+			uid
+			xid
+			name
+		}
+	}`
+	type root struct {
+		Pods []models.Pod `json:"pods"`
+	}
+	newRoot := root{}
+	err := dgraph.ExecuteQuery(query, &newRoot)
+	if err != nil {
+		logrus.Errorf("unable to retrieve all live pods: %v", err)
+		return nil
+	}
+	return newRoot.Pods
+}
+
 // RetrievePodsInteractions returns inbound and outbound interactions of a pod
 func RetrievePodsInteractions(name string, isOrphan bool) []byte {
 	var query string

--- a/pkg/controller/eventprocessor/sync.go
+++ b/pkg/controller/eventprocessor/sync.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventprocessor
+
+import (
+	"time"
+
+	"github.com/vmware/purser/pkg/controller/dgraph"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
+	"github.com/vmware/purser/pkg/controller/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// SyncCluster will handle missed events
+func SyncCluster(kubeClient *kubernetes.Clientset) {
+	endTime := time.Now().Format(time.RFC3339)
+	syncPodsAndContainers(kubeClient, endTime)
+}
+
+// syncPodsAndContainers gets pods through k8s api and from dgraph.
+// Compares between these two sets and add endTime to those pods in dgraph but not in cluster.
+// Creates pod in dgraph which are in cluster but not in dgraph.
+func syncPodsAndContainers(kubeClient *kubernetes.Clientset, endTime string) {
+	logrus.Infof("[SYNC] started syncing pods")
+	livePodsFromDgraph := query.RetrieveAllLivePods()
+	logrus.Infof("[SYNC] number of livePodsFromDgraph: %d", len(livePodsFromDgraph))
+
+	podsInCluster := utils.RetrievePodList(kubeClient, v1.ListOptions{})
+	if podsInCluster == nil {
+		logrus.Errorf("[SYNC] got no podsInCluster, aborting sync")
+		return
+	}
+	logrus.Debugf("[SYNC] number of pods in cluster: %d", len(podsInCluster.Items))
+
+	var updatedPods []models.Pod
+	for _, pod := range livePodsFromDgraph {
+		logrus.Debugf("[SYNC] Name: %s, XID: %s, UID: %v", pod.Name, pod.Xid, pod.UID)
+		pod.EndTime = endTime
+		updatedPods = append(updatedPods, pod)
+
+		podData := models.RetrievePodWithContainers(pod.Xid)
+		models.SoftDeleteContainersInTerminatedPod(podData.Containers, endTime)
+	}
+	_, err := dgraph.MutateNode(updatedPods, dgraph.UPDATE)
+	if err != nil {
+		logrus.Errorf("[SYNC] unable to update pods with end time: %v", err)
+	}
+
+	// stores new pod in dgraph if not persisted in it.
+	// updates (deletes existing pod data and creates a new pod) if it is already persisted in dgraph.
+	for _, pod := range podsInCluster.Items {
+		logrus.Debugf("[SYNC] storing/updating pod: (name: %s, namespace: %s)", pod.Name, pod.Namespace)
+		err := models.StorePod(pod)
+		if err != nil {
+			logrus.Errorf("[SYNC] unable to store/update pod: (name: %s, namespace: %s), err: %v", pod.Name, pod.Namespace, err)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR purser can handle
- Missed CRUD events for pods, containers
- Some resources such as statefulsets will re-create a pod with same name. In such cases we update end time for these resources in order to show the correct data.
- Refactor

**Which issue(s) this PR fixes**:
Fixes #183 and Fixes #160 

**Special notes for your reviewer**:
Tested on my local environment
