### PR TITLE
Update UI service port from 4200 to 80

### DIFF
--- a/cluster/purser-ui-setup.yaml
+++ b/cluster/purser-ui-setup.yaml
@@ -11,7 +11,7 @@ spec:
     run: purser-ui
   ports:
   - protocol: TCP
-    port: 4200
+    port: 80
     targetPort: 4200
   type: LoadBalancer
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/vmware/purser/blob/master/CONTRIBUTING.md 
-->

**What this PR does / why we need it**:
Some firewalls blocks URLs with ports and return error similar to `Bad Request
This combination of host and port requires TLS.` With this PR we change the default port number from 4200 to 80. This will not require URL to contain port (80 is taken as default if none is mentioned).

**Which issue(s) this PR fixes**:
Fixes #189 