### PR TITLE
Change xid when a resource is soft deleted in dgraph

### DIFF
--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -147,6 +147,7 @@ func deleteContainersInTerminatedPod(containers []*Container, endTime time.Time)
 	for _, container := range containers {
 		container.EndTime = endTime.Format(time.RFC3339)
 		container.Xid += container.EndTime
+		container.Name += "*" + container.EndTime // * in name indicates dead resources
 	}
 	_, err := dgraph.MutateNode(containers, dgraph.UPDATE)
 	if err != nil {

--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -141,9 +141,6 @@ func storeContainerIfNotExist(c api_v1.Container, pod api_v1.Pod, podUID, namesp
 }
 
 func deleteContainersInTerminatedPod(containers []*Container, endTime time.Time) {
-	if containers == nil {
-		return
-	}
 	for _, container := range containers {
 		container.EndTime = endTime.Format(time.RFC3339)
 		container.Xid += container.EndTime

--- a/pkg/controller/dgraph/models/container.go
+++ b/pkg/controller/dgraph/models/container.go
@@ -141,8 +141,12 @@ func storeContainerIfNotExist(c api_v1.Container, pod api_v1.Pod, podUID, namesp
 }
 
 func deleteContainersInTerminatedPod(containers []*Container, endTime time.Time) {
+	if containers == nil {
+		return
+	}
 	for _, container := range containers {
 		container.EndTime = endTime.Format(time.RFC3339)
+		container.Xid += container.EndTime
 	}
 	_, err := dgraph.MutateNode(containers, dgraph.UPDATE)
 	if err != nil {

--- a/pkg/controller/dgraph/models/daemonset.go
+++ b/pkg/controller/dgraph/models/daemonset.go
@@ -58,6 +58,7 @@ func createDaemonsetObject(daemonset ext_v1beta1.DaemonSet) Daemonset {
 	if !daemonsetDeletionTimestamp.IsZero() {
 		newDaemonset.EndTime = daemonsetDeletionTimestamp.Time.Format(time.RFC3339)
 		newDaemonset.Xid += newDaemonset.EndTime
+		newDaemonset.Name += "*" + newDaemonset.EndTime
 	}
 	return newDaemonset
 }

--- a/pkg/controller/dgraph/models/daemonset.go
+++ b/pkg/controller/dgraph/models/daemonset.go
@@ -57,6 +57,7 @@ func createDaemonsetObject(daemonset ext_v1beta1.DaemonSet) Daemonset {
 	daemonsetDeletionTimestamp := daemonset.GetDeletionTimestamp()
 	if !daemonsetDeletionTimestamp.IsZero() {
 		newDaemonset.EndTime = daemonsetDeletionTimestamp.Time.Format(time.RFC3339)
+		newDaemonset.Xid += newDaemonset.EndTime
 	}
 	return newDaemonset
 }

--- a/pkg/controller/dgraph/models/deployment.go
+++ b/pkg/controller/dgraph/models/deployment.go
@@ -59,6 +59,7 @@ func createDeploymentObject(deployment apps_v1beta1.Deployment) Deployment {
 	if !deploymentDeletionTimestamp.IsZero() {
 		newDeployment.EndTime = deploymentDeletionTimestamp.Time.Format(time.RFC3339)
 		newDeployment.Xid += newDeployment.EndTime
+		newDeployment.Name += "*" + newDeployment.EndTime
 	}
 	return newDeployment
 }

--- a/pkg/controller/dgraph/models/deployment.go
+++ b/pkg/controller/dgraph/models/deployment.go
@@ -58,6 +58,7 @@ func createDeploymentObject(deployment apps_v1beta1.Deployment) Deployment {
 	deploymentDeletionTimestamp := deployment.GetDeletionTimestamp()
 	if !deploymentDeletionTimestamp.IsZero() {
 		newDeployment.EndTime = deploymentDeletionTimestamp.Time.Format(time.RFC3339)
+		newDeployment.Xid += newDeployment.EndTime
 	}
 	return newDeployment
 }

--- a/pkg/controller/dgraph/models/job.go
+++ b/pkg/controller/dgraph/models/job.go
@@ -57,6 +57,7 @@ func createJobObject(job batch_v1.Job) Job {
 	jobDeletionTimestamp := job.GetDeletionTimestamp()
 	if !jobDeletionTimestamp.IsZero() {
 		newJob.EndTime = jobDeletionTimestamp.Time.Format(time.RFC3339)
+		newJob.Xid += newJob.EndTime
 	}
 	return newJob
 }

--- a/pkg/controller/dgraph/models/job.go
+++ b/pkg/controller/dgraph/models/job.go
@@ -58,6 +58,7 @@ func createJobObject(job batch_v1.Job) Job {
 	if !jobDeletionTimestamp.IsZero() {
 		newJob.EndTime = jobDeletionTimestamp.Time.Format(time.RFC3339)
 		newJob.Xid += newJob.EndTime
+		newJob.Name += "*" + newJob.EndTime
 	}
 	return newJob
 }

--- a/pkg/controller/dgraph/models/namespace.go
+++ b/pkg/controller/dgraph/models/namespace.go
@@ -53,6 +53,7 @@ func newNamespace(namespace api_v1.Namespace) Namespace {
 	nsDeletionTimestamp := namespace.GetDeletionTimestamp()
 	if !nsDeletionTimestamp.IsZero() {
 		ns.EndTime = nsDeletionTimestamp.Time.Format(time.RFC3339)
+		ns.Xid += ns.EndTime
 	}
 	return ns
 }

--- a/pkg/controller/dgraph/models/namespace.go
+++ b/pkg/controller/dgraph/models/namespace.go
@@ -54,6 +54,7 @@ func newNamespace(namespace api_v1.Namespace) Namespace {
 	if !nsDeletionTimestamp.IsZero() {
 		ns.EndTime = nsDeletionTimestamp.Time.Format(time.RFC3339)
 		ns.Xid += ns.EndTime
+		ns.Name += "*" + ns.EndTime
 	}
 	return ns
 }

--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -74,6 +74,7 @@ func createNodeObject(node api_v1.Node) Node {
 	if !nodeDeletionTimestamp.IsZero() {
 		newNode.EndTime = nodeDeletionTimestamp.Time.Format(time.RFC3339)
 		newNode.Xid += newNode.EndTime
+		newNode.Name += "*" + newNode.EndTime
 	}
 	return newNode
 }

--- a/pkg/controller/dgraph/models/node.go
+++ b/pkg/controller/dgraph/models/node.go
@@ -73,6 +73,7 @@ func createNodeObject(node api_v1.Node) Node {
 	nodeDeletionTimestamp := node.GetDeletionTimestamp()
 	if !nodeDeletionTimestamp.IsZero() {
 		newNode.EndTime = nodeDeletionTimestamp.Time.Format(time.RFC3339)
+		newNode.Xid += newNode.EndTime
 	}
 	return newNode
 }

--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -116,6 +116,7 @@ func StorePod(k8sPod api_v1.Pod) error {
 		pod = Pod{
 			ID:      dgraph.ID{Xid: xid + endTime, UID: uid},
 			EndTime: endTime,
+			Name:    "pod-" + k8sPod.Name + "*" + endTime,
 		}
 		podData := RetrievePodWithContainers(xid)
 		deleteContainersInTerminatedPod(podData.Containers, podDeletedTimestamp.Time)

--- a/pkg/controller/dgraph/models/pv.go
+++ b/pkg/controller/dgraph/models/pv.go
@@ -64,6 +64,7 @@ func createPersistentVolumeObject(pv api_v1.PersistentVolume, client *kubernetes
 	if !deletionTimestamp.IsZero() {
 		newPv.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 		newPv.Xid += newPv.EndTime
+		newPv.Name += "*" + newPv.EndTime
 	}
 	return newPv
 }

--- a/pkg/controller/dgraph/models/pv.go
+++ b/pkg/controller/dgraph/models/pv.go
@@ -18,9 +18,10 @@
 package models
 
 import (
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
-	"time"
 
 	"log"
 
@@ -62,6 +63,7 @@ func createPersistentVolumeObject(pv api_v1.PersistentVolume, client *kubernetes
 	deletionTimestamp := pv.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
 		newPv.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
+		newPv.Xid += newPv.EndTime
 	}
 	return newPv
 }

--- a/pkg/controller/dgraph/models/pvc.go
+++ b/pkg/controller/dgraph/models/pvc.go
@@ -69,6 +69,7 @@ func createPvcObject(pvc api_v1.PersistentVolumeClaim) PersistentVolumeClaim {
 	deletionTimestamp := pvc.GetDeletionTimestamp()
 	if !deletionTimestamp.IsZero() {
 		newPvc.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
+		newPvc.Xid += newPvc.EndTime
 	}
 	return newPvc
 }

--- a/pkg/controller/dgraph/models/pvc.go
+++ b/pkg/controller/dgraph/models/pvc.go
@@ -70,6 +70,7 @@ func createPvcObject(pvc api_v1.PersistentVolumeClaim) PersistentVolumeClaim {
 	if !deletionTimestamp.IsZero() {
 		newPvc.EndTime = deletionTimestamp.Time.Format(time.RFC3339)
 		newPvc.Xid += newPvc.EndTime
+		newPvc.Name += "*" + newPvc.EndTime
 	}
 	return newPvc
 }

--- a/pkg/controller/dgraph/models/replicaset.go
+++ b/pkg/controller/dgraph/models/replicaset.go
@@ -58,6 +58,7 @@ func createReplicasetObject(replicaset ext_v1beta1.ReplicaSet) Replicaset {
 	replicasetDeletionTimestamp := replicaset.GetDeletionTimestamp()
 	if !replicasetDeletionTimestamp.IsZero() {
 		newReplicaset.EndTime = replicasetDeletionTimestamp.Time.Format(time.RFC3339)
+		newReplicaset.Xid = newReplicaset.EndTime
 	}
 	setReplicasetOwners(&newReplicaset, replicaset)
 	return newReplicaset

--- a/pkg/controller/dgraph/models/replicaset.go
+++ b/pkg/controller/dgraph/models/replicaset.go
@@ -58,7 +58,8 @@ func createReplicasetObject(replicaset ext_v1beta1.ReplicaSet) Replicaset {
 	replicasetDeletionTimestamp := replicaset.GetDeletionTimestamp()
 	if !replicasetDeletionTimestamp.IsZero() {
 		newReplicaset.EndTime = replicasetDeletionTimestamp.Time.Format(time.RFC3339)
-		newReplicaset.Xid = newReplicaset.EndTime
+		newReplicaset.Xid += newReplicaset.EndTime
+		newReplicaset.Name += "*" + newReplicaset.EndTime
 	}
 	setReplicasetOwners(&newReplicaset, replicaset)
 	return newReplicaset

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -76,9 +76,10 @@ func StoreService(service api_v1.Service) error {
 
 	svcDeletionTimestamp := service.GetDeletionTimestamp()
 	if !svcDeletionTimestamp.IsZero() {
+		et := svcDeletionTimestamp.Time.Format(time.RFC3339)
 		updatedService := Service{
-			ID:      dgraph.ID{Xid: xid, UID: uid},
-			EndTime: svcDeletionTimestamp.Time.Format(time.RFC3339),
+			ID:      dgraph.ID{Xid: xid + et, UID: uid},
+			EndTime: et,
 		}
 		_, err := dgraph.MutateNode(updatedService, dgraph.UPDATE)
 		return err

--- a/pkg/controller/dgraph/models/service.go
+++ b/pkg/controller/dgraph/models/service.go
@@ -80,6 +80,7 @@ func StoreService(service api_v1.Service) error {
 		updatedService := Service{
 			ID:      dgraph.ID{Xid: xid + et, UID: uid},
 			EndTime: et,
+			Name:    "service-" + service.Name + "*" + et,
 		}
 		_, err := dgraph.MutateNode(updatedService, dgraph.UPDATE)
 		return err

--- a/pkg/controller/dgraph/models/statefulset.go
+++ b/pkg/controller/dgraph/models/statefulset.go
@@ -57,6 +57,7 @@ func createStatefulsetObject(statefulset apps_v1beta1.StatefulSet) Statefulset {
 	statefulsetDeletionTimestamp := statefulset.GetDeletionTimestamp()
 	if !statefulsetDeletionTimestamp.IsZero() {
 		newStatefulset.EndTime = statefulsetDeletionTimestamp.Time.Format(time.RFC3339)
+		newStatefulset.Xid += newStatefulset.EndTime
 	}
 	return newStatefulset
 }

--- a/pkg/controller/dgraph/models/statefulset.go
+++ b/pkg/controller/dgraph/models/statefulset.go
@@ -58,6 +58,7 @@ func createStatefulsetObject(statefulset apps_v1beta1.StatefulSet) Statefulset {
 	if !statefulsetDeletionTimestamp.IsZero() {
 		newStatefulset.EndTime = statefulsetDeletionTimestamp.Time.Format(time.RFC3339)
 		newStatefulset.Xid += newStatefulset.EndTime
+		newStatefulset.Name += "*" + newStatefulset.EndTime
 	}
 	return newStatefulset
 }

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -1,7 +1,6 @@
 <div class="main-container">
     <header class="header header-6">
         <div class="branding appHeader">
-            <clr-icon shape="vm-bug"></clr-icon>
             <span>{{messages && messages.common.appHeader}}</span>
         </div>
     </header>


### PR DESCRIPTION
**What this PR does / why we need it**:
It updates the xid, name for the resource when delete event is captured for it.
This will allow dgraph to view the new resources as different as older ones even if the names match.
- Fixes Bug in handling statefulsets and other similar resources
- Remove vm logo in UI

**Which issue(s) this PR fixes**:
Fixes #191