### PR TITLE
Fix cost computation for resources from older months

### DIFF
--- a/pkg/controller/dgraph/models/pod.go
+++ b/pkg/controller/dgraph/models/pod.go
@@ -97,6 +97,10 @@ func newPod(k8sPod api_v1.Pod) (*api.Assigned, error) {
 // StorePod updates the pod details and create it a new node if not exists.
 // It also populates Containers of a pod.
 func StorePod(k8sPod api_v1.Pod) error {
+	if k8sPod.Namespace == "" || k8sPod.Name == "" {
+		return fmt.Errorf("pod name/namespace is empty, name: %s, namesapce: %s", k8sPod.Name, k8sPod.Namespace)
+	}
+
 	xid := k8sPod.Namespace + ":" + k8sPod.Name
 	uid := dgraph.GetUID(xid, IsPod)
 

--- a/pkg/controller/dgraph/models/query/cluster.go
+++ b/pkg/controller/dgraph/models/query/cluster.go
@@ -82,7 +82,7 @@ func RetrieveClusterMetrics(view string) JSONDataWrapper {
 				et as endTime
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+				durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 				pricePerCPU as cpuPrice
 				pricePerMemory as memoryPrice
 				cpuCost: math(cpu * durationInHours * pricePerCPU)
@@ -103,7 +103,7 @@ func RetrieveClusterMetrics(view string) JSONDataWrapper {
 					et as endTime
 					isTerminated as count(endTime)
 					secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-					durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+					durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 					pricePerCPU as cpuPrice
 					pricePerMemory as memoryPrice
 					namespacePodCpuCost as math(namespacePodCpu * durationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/container.go
+++ b/pkg/controller/dgraph/models/query/container.go
@@ -64,7 +64,7 @@ func RetrieveContainerMetrics(name string) JSONDataWrapper {
 			et as endTime
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			cpuCost: math(cpu * durationInHours * ` + models.DefaultCPUCostPerCPUPerHour + `)
 			memoryCost: math(memory * durationInHours * ` + models.DefaultMemCostPerGBPerHour + `)
 		}

--- a/pkg/controller/dgraph/models/query/daemonset.go
+++ b/pkg/controller/dgraph/models/query/daemonset.go
@@ -68,7 +68,7 @@ func RetrieveDaemonsetMetrics(name string) JSONDataWrapper {
 				et as endTime
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+				durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 				pricePerCPU as cpuPrice
 				pricePerMemory as memoryPrice
 				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/deployment.go
+++ b/pkg/controller/dgraph/models/query/deployment.go
@@ -65,7 +65,7 @@ func RetrieveDeploymentMetrics(name string) JSONDataWrapper {
 					replicasetPodET as endTime
 					replicasetPodIsTerminated as count(endTime)
 					replicasetPodSecondsSinceEnd as math(cond(replicasetPodIsTerminated == 0, 0.0, since(replicasetPodET)))
-					replicasetPodDurationInHours as math((replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600)
+					replicasetPodDurationInHours as math(cond(replicasetPodSecondsSinceStart > replicasetPodSecondsSinceEnd, (replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600, 0.0))
 					pricePerCPU as cpuPrice
 					pricePerMemory as memoryPrice
 					replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -95,7 +95,7 @@ func RetrieveGroupMetricsFromPodUIDs(podsUIDs string) (GroupMetrics, error) {
 			isTerminated as count(endTime)
 			isAlive as math(cond(isTerminated == 0, 1, 0))
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			pitPodCPU as math(cond(isTerminated == 0, cond(cpuRequestCount > 0, podCpu, 0.0), 0.0))
 			pitPodMemory as math(cond(isTerminated == 0, cond(memoryRequestCount > 0, podMemory, 0.0), 0.0))
 			pitPvcStorage as math(cond(isTerminated == 0, cond(storageRequestCount > 0, pvcStorage, 0.0), 0.0))

--- a/pkg/controller/dgraph/models/query/job.go
+++ b/pkg/controller/dgraph/models/query/job.go
@@ -68,7 +68,7 @@ func RetrieveJobMetrics(name string) JSONDataWrapper {
 				et as endTime
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+				durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 				pricePerCPU as cpuPrice
 				pricePerMemory as memoryPrice
 				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/namespace.go
+++ b/pkg/controller/dgraph/models/query/namespace.go
@@ -73,7 +73,7 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 						replicasetPodET as endTime
 						replicasetPodIsTerminated as count(endTime)
 						replicasetPodSecondsSinceEnd as math(cond(replicasetPodIsTerminated == 0, 0.0, since(replicasetPodET)))
-						replicasetPodDurationInHours as math((replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600)
+						replicasetPodDurationInHours as math(cond(replicasetPodSecondsSinceStart > replicasetPodSecondsSinceEnd, (replicasetPodSecondsSinceStart - replicasetPodSecondsSinceEnd) / 3600, 0.0))
 						replicasetPricePerCPU as cpuPrice
 						replicasetPricePerMemory as memoryPrice
 						replicasetPodCpuCost as math(replicasetPodCpu * replicasetPodDurationInHours * replicasetPricePerCPU)
@@ -99,7 +99,7 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					statefulsetPodET as endTime
 					statefulsetPodIsTerminated as count(endTime)
 					statefulsetPodSecondsSinceEnd as math(cond(statefulsetPodIsTerminated == 0, 0.0, since(statefulsetPodET)))
-					statefulsetPodDurationInHours as math((statefulsetPodSecondsSinceStart - statefulsetPodSecondsSinceEnd) / 3600)
+					 statefulsetPodDurationInHours as math(cond(statefulsetPodSecondsSinceStart > statefulsetPodSecondsSinceEnd, (statefulsetPodSecondsSinceStart - statefulsetPodSecondsSinceEnd) / 3600, 0.0))
 					statefulsetPricePerCPU as cpuPrice
 					statefulsetPricePerMemory as memoryPrice
 					statefulsetPodCpuCost as math(statefulsetPodCpu * statefulsetPodDurationInHours * statefulsetPricePerCPU)
@@ -118,7 +118,7 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					jobPodET as endTime
 					jobPodIsTerminated as count(endTime)
 					jobPodSecondsSinceEnd as math(cond(jobPodIsTerminated == 0, 0.0, since(jobPodET)))
-					jobPodDurationInHours as math((jobPodSecondsSinceStart - jobPodSecondsSinceEnd) / 3600)
+					jobPodDurationInHours as math(cond(jobPodSecondsSinceStart > jobPodSecondsSinceEnd, (jobPodSecondsSinceStart - jobPodSecondsSinceEnd) / 3600, 0.0))
 					jobPricePerCPU as cpuPrice
 					jobPricePerMemory as memoryPrice
 					jobPodCpuCost as math(jobPodCpu * jobPodDurationInHours * jobPricePerCPU)
@@ -137,7 +137,7 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					daemonsetPodET as endTime
 					daemonsetPodIsTerminated as count(endTime)
 					daemonsetPodSecondsSinceEnd as math(cond(daemonsetPodIsTerminated == 0, 0.0, since(daemonsetPodET)))
-					daemonsetPodDurationInHours as math((daemonsetPodSecondsSinceStart - daemonsetPodSecondsSinceEnd) / 3600)
+					daemonsetPodDurationInHours as math(cond(daemonsetPodSecondsSinceStart > daemonsetPodSecondsSinceEnd, (daemonsetPodSecondsSinceStart - daemonsetPodSecondsSinceEnd) / 3600, 0.0))
 					daemonsetPricePerCPU as cpuPrice
 					daemonsetPricePerMemory as memoryPrice
 					daemonsetPodCpuCost as math(daemonsetPodCpu * daemonsetPodDurationInHours * daemonsetPricePerCPU)
@@ -156,7 +156,7 @@ func RetrieveNamespaceMetrics(name string) JSONDataWrapper {
 					replicasetSimplePodET as endTime
 					replicasetSimplePodIsTerminated as count(endTime)
 					replicasetSimplePodSecondsSinceEnd as math(cond(replicasetSimplePodIsTerminated == 0, 0.0, since(replicasetSimplePodET)))
-					replicasetSimplePodDurationInHours as math((replicasetSimplePodSecondsSinceStart - replicasetSimplePodSecondsSinceEnd) / 3600)
+					replicasetSimplePodDurationInHours as math(cond(replicasetSimplePodSecondsSinceStart > replicasetSimplePodSecondsSinceEnd, (replicasetSimplePodSecondsSinceStart - replicasetSimplePodSecondsSinceEnd) / 3600, 0.0))
 					replicasetSimplePricePerCPU as cpuPrice
 					replicasetSimplePricePerMemory as memoryPrice
 					replicasetSimplePodCpuCost as math(replicasetSimplePodCpu * replicasetSimplePodDurationInHours * replicasetSimplePricePerCPU)

--- a/pkg/controller/dgraph/models/query/node.go
+++ b/pkg/controller/dgraph/models/query/node.go
@@ -70,7 +70,7 @@ func RetrieveNodeMetrics(name string) JSONDataWrapper {
 				etChild as endTime
 				isTerminatedChild as count(endTime)
 				secondsSinceEndChild as math(cond(isTerminatedChild == 0, 0.0, since(etChild)))
-				durationInHoursChild as math((secondsSinceStartChild - secondsSinceEndChild) / 3600)
+				durationInHoursChild as math(cond(secondsSinceStartChild > secondsSinceEndChild, (secondsSinceStartChild - secondsSinceEndChild) / 3600, 0.0))
 				podPricePerCPU as cpuPrice
 				podPricePerMemory as memoryPrice
 				cpuCost: math(podCpu * durationInHoursChild * podPricePerCPU)
@@ -86,7 +86,7 @@ func RetrieveNodeMetrics(name string) JSONDataWrapper {
 			et as endTime
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			pricePerCPU as cpuPrice
 			pricePerMemory as memoryPrice
 			cpuCost: math(cpu * durationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/pod.go
+++ b/pkg/controller/dgraph/models/query/pod.go
@@ -142,7 +142,7 @@ func RetrievePodMetrics(name string) JSONDataWrapper {
 				etChild as endTime
 				isTerminatedChild as count(endTime)
 				secondsSinceEndChild as math(cond(isTerminatedChild == 0, 0.0, since(etChild)))
-				durationInHoursChild as math((secondsSinceStartChild - secondsSinceEndChild) / 3600)
+				durationInHoursChild as math(cond(secondsSinceStartChild > secondsSinceEndChild, (secondsSinceStartChild - secondsSinceEndChild) / 3600, 0.0))
 				cpu: cpu as cpuRequest
 				memory: memory as memoryRequest
 				cpuCost: math(cpu * durationInHoursChild * ` + cpuPrice + `)
@@ -157,7 +157,7 @@ func RetrievePodMetrics(name string) JSONDataWrapper {
 			et as endTime
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			cpuCost: math(podCpu * durationInHours * ` + cpuPrice + `)
 			memoryCost: math(podMemory * durationInHours * ` + memoryPrice + `)
 			storageCost: math(pvcStorage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)

--- a/pkg/controller/dgraph/models/query/pv.go
+++ b/pkg/controller/dgraph/models/query/pv.go
@@ -68,7 +68,7 @@ func RetrievePVMetrics(name string) JSONDataWrapper {
 				etChild as endTime
 				isTerminatedChild as count(endTime)
 				secondsSinceEndChild as math(cond(isTerminatedChild == 0, 0.0, since(etChild)))
-				durationInHoursChild as math((secondsSinceStartChild - secondsSinceEndChild) / 3600)
+				durationInHoursChild as math(cond(secondsSinceStartChild > secondsSinceEndChild, (secondsSinceStartChild - secondsSinceEndChild) / 3600, 0.0))
 				storageCost: math(pvcStorage * durationInHoursChild * ` + models.DefaultStorageCostPerGBPerHour + `)
 			}
 			storage: storage as storageCapacity
@@ -78,7 +78,7 @@ func RetrievePVMetrics(name string) JSONDataWrapper {
 			et as endTime
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
         }
     }`

--- a/pkg/controller/dgraph/models/query/pvc.go
+++ b/pkg/controller/dgraph/models/query/pvc.go
@@ -45,7 +45,7 @@ func RetrievePVCMetrics(name string) JSONDataWrapper {
 			et as endTime
 			isTerminated as count(endTime)
 			secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-			durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+			durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 			storageCost: math(storage * durationInHours * ` + models.DefaultStorageCostPerGBPerHour + `)
         }
     }`

--- a/pkg/controller/dgraph/models/query/replicaset.go
+++ b/pkg/controller/dgraph/models/query/replicaset.go
@@ -68,7 +68,7 @@ func RetrieveReplicasetMetrics(name string) JSONDataWrapper {
 				et as endTime
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+				durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 				pricePerCPU as cpuPrice
 				pricePerMemory as memoryPrice
 				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)

--- a/pkg/controller/dgraph/models/query/statefulset.go
+++ b/pkg/controller/dgraph/models/query/statefulset.go
@@ -68,7 +68,7 @@ func RetrieveStatefulsetMetrics(name string) JSONDataWrapper {
 				et as endTime
 				isTerminated as count(endTime)
 				secondsSinceEnd as math(cond(isTerminated == 0, 0.0, since(et)))
-				durationInHours as math((secondsSinceStart - secondsSinceEnd) / 3600)
+				durationInHours as math(cond(secondsSinceStart > secondsSinceEnd, (secondsSinceStart - secondsSinceEnd) / 3600, 0.0))
 				pricePerCPU as cpuPrice
 				pricePerMemory as memoryPrice
 				cpuCost: podCpuCost as math(podCpu * durationInHours * pricePerCPU)


### PR DESCRIPTION
**What this PR does / why we need it**:
If both start time and end time of a resource is from previous month then Month To Date cost of that resource will be zero

**Which issue(s) this PR fixes**:
Fixes #196 

**Special notes for your reviewer**:
Tested on my local setup