### PR TITLE
Support group creation in YAML format

### DIFF
--- a/cmd/controller/api/apiHandlers/helpers.go
+++ b/cmd/controller/api/apiHandlers/helpers.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"io"
 	"net/http"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func addHeaders(w *http.ResponseWriter, r *http.Request) {
@@ -47,4 +49,13 @@ func encodeAndWrite(w io.Writer, obj interface{}) {
 	if err != nil {
 		logrus.Errorf("Unable to encode to json: (%v)", err)
 	}
+}
+
+func convertRequestBodyToJSON(r *http.Request) ([]byte, error) {
+	requestData, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	groupData, err := yaml.ToJSON(requestData)
+	return groupData, err
 }

--- a/pkg/controller/dgraph/models/query/metrics.go
+++ b/pkg/controller/dgraph/models/query/metrics.go
@@ -188,7 +188,7 @@ func getQueryForNamespaceMetrics(name string) string {
 func getMetricsQueryForLogicalResources() string {
 	return `query {
 			ns as var(func: has(isNamespace)) {
-				~namespace @filter(has(isPod)){
+				~namespace @filter(has(isPod) AND (NOT has(endTime))) {
 					` + getQueryForMetricsComputation("NamespacePod") + `
 				}
 				` + getQueryForAggregatingChildMetrics("Namespace", "NamespacePod") + `
@@ -203,7 +203,7 @@ func getMetricsQueryForLogicalResources() string {
 // PhysicalResourcesMetrics query
 func getMetricsQueryForPhysicalResources() string {
 	return `query {
-			children(func: has(name)) @filter(has(isNode) OR has(isPersistentVolume)) {
+			children(func: has(name)) @filter((has(isNode) OR has(isPersistentVolume)) AND (NOT has(endTime))) {
 				name
 			type
 			cpu: cpu as cpuCapacity

--- a/ui/src/app/modules/logical-group/components/logical-group.component.ts
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.ts
@@ -28,7 +28,6 @@ export class LogicalGroupComponent implements OnInit {
   public group: any;
 
   constructor(private router: Router, private logicalGroupService: LogicalGroupService) {
-    setInterval(() => this.ngOnInit(), 60000);
    }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- At present in Purser UI, groups are created by using JSON. Having YAML support too will be helpful as it is more human readable.
- Show metrics for only live resources
- Remove cron refresh in UI

**Which issue(s) this PR fixes**:
Fixes #216 

**Special notes for your reviewer**:
Tested
