### PR TITLE
Compute projected costs and show it in UI

### DIFF
--- a/cmd/controller/api/apiHandlers/customGroupHandlers.go
+++ b/cmd/controller/api/apiHandlers/customGroupHandlers.go
@@ -23,7 +23,9 @@ import (
 	group_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
 	"github.com/vmware/purser/pkg/client/clientset/typed/groups/v1"
 	"github.com/vmware/purser/pkg/controller"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
 	"github.com/vmware/purser/pkg/controller/dgraph/models/query"
+	"github.com/vmware/purser/pkg/controller/eventprocessor"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 )
@@ -55,6 +57,7 @@ func DeleteGroup(w http.ResponseWriter, r *http.Request) {
 			err = getGroupClient().Delete(name[0], &meta_v1.DeleteOptions{})
 			if err == nil {
 				w.WriteHeader(http.StatusOK)
+				models.DeleteGroup(name[0])
 				return
 			}
 		}
@@ -86,6 +89,7 @@ func CreateGroup(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+		eventprocessor.UpdateGroup(&newGroup, getGroupClient())
 	}
 }
 

--- a/cmd/controller/api/apiHandlers/helpers.go
+++ b/cmd/controller/api/apiHandlers/helpers.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"github.com/Sirupsen/logrus"
 	"io"
-	"net/http"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"net/http"
 )
 
 func addHeaders(w *http.ResponseWriter, r *http.Request) {

--- a/pkg/apis/groups/v1/types.go
+++ b/pkg/apis/groups/v1/types.go
@@ -49,6 +49,7 @@ type GroupSpec struct {
 	PITMetrics         *GroupMetrics                  `json:"pitMetrics,omitempty"`
 	MTDMetrics         *GroupMetrics                  `json:"mtdMetrics,omitempty"`
 	MTDCost            *Cost                          `json:"mtdCost,omitempty"`
+	PerHourCost        *Cost                          `json:"perHourCost,omitempty"`
 	LastUpdated        time.Time                      `json:"lastUpdated,omitempty"`
 }
 

--- a/pkg/controller/dgraph/models/group.go
+++ b/pkg/controller/dgraph/models/group.go
@@ -22,52 +22,62 @@ import (
 	"github.com/dgraph-io/dgo/protos/api"
 	groups_v1 "github.com/vmware/purser/pkg/apis/groups/v1"
 	"github.com/vmware/purser/pkg/controller/dgraph"
+	"github.com/vmware/purser/pkg/controller/utils"
 )
 
 // Group constants
 const (
-	IsGroup   = "isGroup"
-	XIDPrefix = "purser-group-"
+	IsGroup        = "isGroup"
+	groupXIDPrefix = "purser-group-"
 )
 
 // Group schema in dgraph
 type Group struct {
 	dgraph.ID
-	IsGroup        bool    `json:"isGroup,omitempty"`
-	Name           string  `json:"name,omitempty"`
-	PodsCount      int     `json:"podsCount,omitempty"`
-	MtdCPU         float64 `json:"mtdCPU,omitempty"`
-	MtdMemory      float64 `json:"mtdMemory,omitempty"`
-	MtdStorage     float64 `json:"mtdStorage,omitempty"`
-	CPU            float64 `json:"cpu,omitempty"`
-	Memory         float64 `json:"memory,omitempty"`
-	Storage        float64 `json:"storage,omitempty"`
-	MtdCPUCost     float64 `json:"mtdCPUCost,omitempty"`
-	MtdMemoryCost  float64 `json:"mtdMemoryCost,omitempty"`
-	MtdStorageCost float64 `json:"mtdStorageCost,omitempty"`
-	MtdCost        float64 `json:"mtdCost,omitempty"`
+	IsGroup              bool    `json:"isGroup,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	PodsCount            int     `json:"podsCount,omitempty"`
+	MtdCPU               float64 `json:"mtdCPU,omitempty"`
+	MtdMemory            float64 `json:"mtdMemory,omitempty"`
+	MtdStorage           float64 `json:"mtdStorage,omitempty"`
+	CPU                  float64 `json:"cpu,omitempty"`
+	Memory               float64 `json:"memory,omitempty"`
+	Storage              float64 `json:"storage,omitempty"`
+	MtdCPUCost           float64 `json:"mtdCPUCost,omitempty"`
+	MtdMemoryCost        float64 `json:"mtdMemoryCost,omitempty"`
+	MtdStorageCost       float64 `json:"mtdStorageCost,omitempty"`
+	MtdCost              float64 `json:"mtdCost,omitempty"`
+	ProjectedCPUCost     float64 `json:"projectedCPUCost,omitempty"`
+	ProjectedMemoryCost  float64 `json:"projectedMemoryCost,omitempty"`
+	ProjectedStorageCost float64 `json:"projectedStorageCost,omitempty"`
+	ProjectedCost        float64 `json:"projectedCost,omitempty"`
 }
 
 // CreateOrUpdateGroup updates group if it is already present in dgraph else it creates one
 func CreateOrUpdateGroup(group *groups_v1.Group, podsCount int) (*api.Assigned, error) {
-	xid := XIDPrefix + group.Name
+	xid := groupXIDPrefix + group.Name
 	uid := dgraph.GetUID(xid, IsGroup)
 
+	hoursRemainingInCurrentMonth := utils.GetHoursRemainingInCurrentMonth()
 	grp := Group{
-		ID:             dgraph.ID{Xid: xid},
-		IsGroup:        true,
-		Name:           group.Name,
-		PodsCount:      podsCount,
-		MtdCPU:         group.Spec.MTDMetrics.CPURequest,
-		MtdMemory:      group.Spec.MTDMetrics.MemoryRequest,
-		MtdStorage:     group.Spec.MTDMetrics.StorageClaim,
-		CPU:            group.Spec.PITMetrics.CPURequest,
-		Memory:         group.Spec.PITMetrics.MemoryRequest,
-		Storage:        group.Spec.PITMetrics.StorageClaim,
-		MtdCPUCost:     group.Spec.MTDCost.CPUCost,
-		MtdMemoryCost:  group.Spec.MTDCost.MemoryCost,
-		MtdStorageCost: group.Spec.MTDCost.StorageCost,
-		MtdCost:        group.Spec.MTDCost.TotalCost,
+		ID:                   dgraph.ID{Xid: xid},
+		IsGroup:              true,
+		Name:                 group.Name,
+		PodsCount:            podsCount,
+		MtdCPU:               group.Spec.MTDMetrics.CPURequest,
+		MtdMemory:            group.Spec.MTDMetrics.MemoryRequest,
+		MtdStorage:           group.Spec.MTDMetrics.StorageClaim,
+		CPU:                  group.Spec.PITMetrics.CPURequest,
+		Memory:               group.Spec.PITMetrics.MemoryRequest,
+		Storage:              group.Spec.PITMetrics.StorageClaim,
+		MtdCPUCost:           group.Spec.MTDCost.CPUCost,
+		MtdMemoryCost:        group.Spec.MTDCost.MemoryCost,
+		MtdStorageCost:       group.Spec.MTDCost.StorageCost,
+		MtdCost:              group.Spec.MTDCost.TotalCost,
+		ProjectedCPUCost:     group.Spec.MTDCost.CPUCost + group.Spec.PerHourCost.CPUCost*hoursRemainingInCurrentMonth,
+		ProjectedMemoryCost:  group.Spec.MTDCost.MemoryCost + group.Spec.PerHourCost.MemoryCost*hoursRemainingInCurrentMonth,
+		ProjectedStorageCost: group.Spec.MTDCost.StorageCost + group.Spec.PerHourCost.StorageCost*hoursRemainingInCurrentMonth,
+		ProjectedCost:        group.Spec.MTDCost.TotalCost + group.Spec.PerHourCost.TotalCost*hoursRemainingInCurrentMonth,
 	}
 	if uid != "" {
 		grp.ID = dgraph.ID{Xid: xid, UID: uid}
@@ -77,7 +87,7 @@ func CreateOrUpdateGroup(group *groups_v1.Group, podsCount int) (*api.Assigned, 
 
 // DeleteGroup deletes group from dgraph
 func DeleteGroup(name string) {
-	xid := XIDPrefix + name
+	xid := groupXIDPrefix + name
 	uid := dgraph.GetUID(xid, IsGroup)
 
 	if uid != "" {

--- a/pkg/controller/dgraph/models/query/group.go
+++ b/pkg/controller/dgraph/models/query/group.go
@@ -25,20 +25,23 @@ import (
 
 // GroupMetrics structure
 type GroupMetrics struct {
-	PITCpu         float64
-	PITMemory      float64
-	PITStorage     float64
-	PITCpuLimit    float64
-	PITMemoryLimit float64
-	MTDCpu         float64
-	MTDMemory      float64
-	MTDStorage     float64
-	MTDCpuLimit    float64
-	MTDMemoryLimit float64
-	CostCPU        float64
-	CostMemory     float64
-	CostStorage    float64
-	PodsCount      int
+	PITCpu             float64
+	PITMemory          float64
+	PITStorage         float64
+	PITCpuLimit        float64
+	PITMemoryLimit     float64
+	MTDCpu             float64
+	MTDMemory          float64
+	MTDStorage         float64
+	MTDCpuLimit        float64
+	MTDMemoryLimit     float64
+	CostCPU            float64
+	CostMemory         float64
+	CostStorage        float64
+	CostCPUPerHour     float64
+	CostMemoryPerHour  float64
+	CostStoragePerHour float64
+	PodsCount          int
 }
 
 type groupsRoot struct {
@@ -116,6 +119,12 @@ func populateMetric(groupMetrics *GroupMetrics, key string, value float64) {
 		groupMetrics.CostMemory = value
 	case "storageCost":
 		groupMetrics.CostStorage = value
+	case "cpuCostPerHour":
+		groupMetrics.CostCPUPerHour = value
+	case "memoryCostPerHour":
+		groupMetrics.CostMemoryPerHour = value
+	case "storageCostPerHour":
+		groupMetrics.CostStoragePerHour = value
 	case "livePods":
 		groupMetrics.PodsCount = int(value)
 	}

--- a/pkg/controller/dgraph/models/query/queries.go
+++ b/pkg/controller/dgraph/models/query/queries.go
@@ -254,6 +254,10 @@ func getQueryForAllGroupsData() string {
 			mtdMemoryCost
 			mtdStorageCost
 			mtdCost
+			projectedCPUCost
+			projectedMemoryCost
+			projectedStorageCost
+			projectedCost
 		}
 	}`
 }
@@ -288,6 +292,9 @@ func getQueryForGroupMetrics(podsUIDs string) string {
 			podCpuCost as math(mtdPodCPU * pricePerCPU)
 			podMemoryCost as math(mtdPodMemory * pricePerMemory)
 			podStorageCost as math(mtdPvcStorage * ` + models.DefaultStorageCostPerGBPerHour + `)
+			podCPUCostPerHour as math(pitPodCPU * pricePerCPU)
+			podMemoryCostPerHour as math(pitPodMemory * pricePerMemory)
+			podStorageCostPerHour as math(pitPvcStorage * ` + models.DefaultStorageCostPerGBPerHour + `)
 		}
 		
 		group() {
@@ -304,6 +311,9 @@ func getQueryForGroupMetrics(podsUIDs string) string {
 			cpuCost: sum(val(podCpuCost))
 			memoryCost: sum(val(podMemoryCost))
 			storageCost: sum(val(podStorageCost))
+			cpuCostPerHour: sum(val(podCPUCostPerHour))
+			memoryCostPerHour: sum(val(podMemoryCostPerHour))
+			storageCostPerHour: sum(val(podStorageCostPerHour))
 			livePods: sum(val(isAlive))
 		}
 	}`

--- a/pkg/controller/eventprocessor/updater.go
+++ b/pkg/controller/eventprocessor/updater.go
@@ -71,6 +71,12 @@ func UpdateGroup(group *groups_v1.Group, groupCRDClient *groupsClient_v1.GroupCl
 		StorageCost: groupMetrics.CostStorage,
 		TotalCost:   groupMetrics.CostCPU + groupMetrics.CostMemory + groupMetrics.CostStorage,
 	}
+	group.Spec.PerHourCost = &groups_v1.Cost{
+		CPUCost:     groupMetrics.CostCPUPerHour,
+		MemoryCost:  groupMetrics.CostMemoryPerHour,
+		StorageCost: groupMetrics.CostStoragePerHour,
+		TotalCost:   groupMetrics.CostCPUPerHour + groupMetrics.CostMemoryPerHour + groupMetrics.CostStoragePerHour,
+	}
 	group.Spec.LastUpdated = time.Now()
 
 	_, err := groupCRDClient.Update(group)

--- a/pkg/controller/utils/timeUtils.go
+++ b/pkg/controller/utils/timeUtils.go
@@ -35,3 +35,10 @@ func ConverTimeToRFC3339(queryTime time.Time) string {
 func GetSecondsSince(queryTime time.Time) float64 {
 	return time.Since(queryTime).Seconds()
 }
+
+// GetHoursRemainingInCurrentMonth returns number of hours remaining in the month
+func GetHoursRemainingInCurrentMonth() float64 {
+	now := time.Now()
+	monthEnd := time.Date(now.Year(), now.Month(), 30, 23, 59, 0, 0, time.Local)
+	return -time.Since(monthEnd).Hours()
+}

--- a/ui/src/app/modules/logical-group/components/logical-group.component.html
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.html
@@ -1,30 +1,30 @@
 <h3>Custom Groups</h3>
 
 <div class="clr-row" style="margin-top: 2%; margin-bottom: -1%">
-  <div class="clr-col-1">
-    <button [clrLoading]="submitBtnState" type="submit" class="btn btn-success-outline" (click)="fillGroupData()">New Group</button>
-  </div>
-  <div class="clr-col-1">
-      <button [clrLoading]="submitBtnState" type="submit" class="btn btn-danger-outline" (click)="deleteGroupData()">Delete</button>
+    <div class="clr-col-4">
+        <button [clrLoading]="submitBtnState" type="submit" class="btn btn-success-outline" (click)="fillGroupData()"><clr-icon shape="plus"></clr-icon> ADD GROUP</button>
     </div>
-  <div class="clr-col-10"></div>
 </div>
 
 <clr-datagrid>
     <clr-dg-column [clrDgField]="'name'">Group Name</clr-dg-column>
-    <clr-dg-column [clrDgField]="'podsCount'">Pods</clr-dg-column>
-    <clr-dg-column [clrDgField]="'cpu'">CPU (vCPU)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'memory'">Memory (GB)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'storage'">Storage (GB)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'mtdCPU'">CPU Cost (US $)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'mtdMemory'">Memory Cost (US $)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'mtdStorage'">Storage Cost (US $)</clr-dg-column>
-    <clr-dg-column [clrDgField]="'mtdCost'">Total Cost (US $)</clr-dg-column>
+    <clr-dg-column [clrDgField]="'podsCount'"><ng-container *clrDgHideableColumn="{hidden: true}">Pods</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'cpu'"><ng-container *clrDgHideableColumn="{hidden: false}">CPU (vCPU)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'memory'"><ng-container *clrDgHideableColumn="{hidden: false}">Memory (GB)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'storage'"><ng-container *clrDgHideableColumn="{hidden: false}">Storage (GB)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdCPU'"><ng-container *clrDgHideableColumn="{hidden: false}">CPU Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdMemory'"><ng-container *clrDgHideableColumn="{hidden: false}">Memory Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdStorage'"><ng-container *clrDgHideableColumn="{hidden: false}">Storage Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'mtdCost'"><ng-container *clrDgHideableColumn="{hidden: false}">Total Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'projectedCPU'"><ng-container *clrDgHideableColumn="{hidden: true}">Projected CPU Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'projectedMemory'"><ng-container *clrDgHideableColumn="{hidden: true}">Projected Memory Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'projectedStorage'"><ng-container *clrDgHideableColumn="{hidden: true}">Projected Storage Cost (US $)</ng-container></clr-dg-column>
+    <clr-dg-column [clrDgField]="'projectedCost'"><ng-container *clrDgHideableColumn="{hidden: true}">Projected Cost (US $)</ng-container></clr-dg-column>
 
     <clr-dg-placeholder>We couldn't find any custom groups! Logged out? Click here to <a href="./login">Signin</a> </clr-dg-placeholder>
 
     <clr-dg-row *clrDgItems="let group of groups">
-      <clr-dg-cell>{{ group.name }}</clr-dg-cell>
+      <clr-dg-cell><button class="btn btn-sm btn-link" style="padding:-4%; margin:-4%; text-align: left" (click)="showGroupDetails(group)">{{ group.name }}</button></clr-dg-cell>
       <clr-dg-cell>{{ group.podsCount }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.cpu | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.memory | number: '1.0-2') || 0 }}</clr-dg-cell>
@@ -33,7 +33,24 @@
       <clr-dg-cell>{{ (group.mtdMemoryCost | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.mtdStorageCost | number: '1.0-2') || 0 }}</clr-dg-cell>
       <clr-dg-cell>{{ (group.mtdCost | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.projectedCPUCost | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.projectedMemoryCost | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.projectedStorageCost | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-cell>{{ (group.projectedCost | number: '1.0-2') || 0 }}</clr-dg-cell>
+      <clr-dg-action-overflow>
+            <button class="action-item" (click)="setToBeDeletedGroup(group.name)"><clr-icon shape="trash"></clr-icon>  DELETE</button>
+        </clr-dg-action-overflow>
     </clr-dg-row>
+
+    <clr-dg-footer>
+        <clr-dg-column-toggle>
+            <clr-dg-column-toggle-title>Hide/Show Features</clr-dg-column-toggle-title>
+            <clr-dg-column-toggle-button>Select All</clr-dg-column-toggle-button>
+        </clr-dg-column-toggle>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
+        of {{pagination.totalItems}} groups
+        <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>
 <p class="p5"><i>* All costs are computed for Month To Date (MTD).</i></p>
 
@@ -58,98 +75,124 @@
 </form>
 
 <clr-modal [(clrModalOpen)]="isDeleteGroup">
-    <h3 class="modal-title">Delete Custom Group</h3>
-    <div class="modal-body">
-        <form class="clr-form clr-form-horizontal">
-            <div class="clr-form-control">
-                <label for="example" class="clr-control-label">Name</label>
-                <div class="clr-control-container">
-                    <clr-dropdown>
-                        <button type="button" class="btn btn-outline-primary" clrDropdownTrigger>
-                            {{ toBeDeletedGroup }}
-                            <clr-icon shape="caret down"></clr-icon>
-                        </button>
-                        <clr-dropdown-menu clrPosition="bottom" *clrIfOpen>
-                            <label class="dropdown-header">Select Group by name</label>
-                            <div *ngFor="let group of groups">
-                                <button type="button" clrDropdownItem (click)="setToBeDeletedGroup(group.name)">{{ group.name }}</button>
-                            </div>
-                        </clr-dropdown-menu>
-                    </clr-dropdown>
-                </div>
-            </div>
-        </form>
-    </div>
+    <h3 class="modal-title">Delete group {{ toBeDeletedGroup }}?</h3>
     <div class="modal-footer">
         <button type="button" class="btn btn-outline" (click)="isDeleteGroup = false">Cancel</button>
         <button type="button" class="btn btn-danger" (click)="deleteGroup()">Delete</button>
     </div>
-  </clr-modal>
+</clr-modal>
 
-    <div *ngIf="groupCreation === 'fail'">
-        <div class="clr-row">
-            <div class="clr-col-8">
-                <clr-alert clrAlertType="danger" [clrAlertClosable]="true">
-                    <clr-alert-item>
-                        <div class="alert-item static">
-                            <span class="alert-text">
-                                Group creation failed<br/><br/>
-                                Error: {{ creationError }}
-                            </span>
-                        </div>
-                    </clr-alert-item>
-                </clr-alert>
+<div *ngIf="groupCreation === 'fail'">
+    <div class="clr-row">
+        <div class="clr-col-8">
+            <clr-alert clrAlertType="danger" [clrAlertClosable]="true">
+                <clr-alert-item>
+                    <div class="alert-item static">
+                        <span class="alert-text">
+                            Group creation failed<br/><br/>
+                            Error: {{ creationError }}
+                        </span>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+        </div>
+    </div>
+</div>
+
+<div *ngIf="groupCreation === 'success'">
+    <div class="clr-row">
+        <div class="clr-col-4">
+            <clr-alert clrAlertType="success" [clrAlertClosable]="true">
+                <clr-alert-item>
+                    <div class="alert-item static">
+                        <span class="alert-text">
+                                Successfully created group.
+                        </span>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+        </div>
+    </div>
+</div>
+
+<div *ngIf="groupDeletion === 'success'">
+    <div class="clr-row">
+        <div class="clr-col-4">
+            <clr-alert clrAlertType="success" [clrAlertClosable]="true">
+                <clr-alert-item>
+                    <div class="alert-item static">
+                        <span class="alert-text">
+                                Successfully deleted group.
+                        </span>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+        </div>
+    </div>
+</div>
+
+<div *ngIf="groupDeletion === 'fail'">
+    <div class="clr-row">
+        <div class="clr-col-8">
+            <clr-alert clrAlertType="danger" [clrAlertClosable]="true">
+                <clr-alert-item>
+                    <div class="alert-item static">
+                        <span class="alert-text">
+                                Group deletion failed<br/><br/>
+                                Error: {{ deletionError }}
+                        </span>
+                    </div>
+                </clr-alert-item>
+            </clr-alert>
+        </div>
+    </div>
+</div>
+
+<div class="clr-row" *ngIf="isShowGroupDetails">
+    <div class="clr-col-lg-5 clr-col-md-8 clr-col-6">
+        <div class="card">
+            <div class="card-header">
+                Group: ({{ groupToFocus.name }}) Resource Details
+            </div>
+            <div class="card-block">
+                <div class="card-text">
+                    Pods      : {{ groupToFocus.podsCount }}<br/>
+                    CPU       : {{ groupToFocus.cpu }}<br/>
+                    Memory    : {{ groupToFocus.memory }}<br/>
+                    Storage   : {{ groupToFocus.storage }}<br/>
+                </div>
+            </div>
+
+            <div class="card-footer">
+                <button class="btn btn-sm btn-link" (click)="showMTD()">MTD Costs</button>
+                <button class="btn btn-sm btn-link" (click)="showProjected()">Projected Costs</button>
             </div>
         </div>
     </div>
+</div>
 
-    <div *ngIf="groupCreation === 'success'">
-        <div class="clr-row">
-            <div class="clr-col-4">
-                <clr-alert clrAlertType="success" [clrAlertClosable]="true">
-                    <clr-alert-item>
-                        <div class="alert-item static">
-                            <span class="alert-text">
-                                    Successfully created group.
-                            </span>
-                        </div>
-                    </clr-alert-item>
-                </clr-alert>
-            </div>
-        </div>
+<clr-modal [(clrModalOpen)]="isShowMTD" [clrModalSize]="'lg'">
+    <h3 class="modal-title">MTD Costs</h3>
+    <div class="modal-body">
+        <div class="googleChartDiv" *ngIf="isShowMTD">
+            <google-chart class="googleChart" [type]="'PieChart'" [data]="donutData.data" [options]="donutOptions" [dynamicResize]="true"></google-chart>
+        </div>        
     </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-outline" (click)="isShowMTD = false">Close</button>
+    </div>
+</clr-modal>
 
-    <div *ngIf="groupDeletion === 'success'">
-        <div class="clr-row">
-            <div class="clr-col-4">
-                <clr-alert clrAlertType="success" [clrAlertClosable]="true">
-                    <clr-alert-item>
-                        <div class="alert-item static">
-                            <span class="alert-text">
-                                    Successfully deleted group.
-                            </span>
-                        </div>
-                    </clr-alert-item>
-                </clr-alert>
-            </div>
-        </div>
+<clr-modal [(clrModalOpen)]="isShowProjected" [clrModalSize]="'lg'">
+    <h3 class="modal-title">MTD Costs</h3>
+    <div class="modal-body">
+        <div class="googleChartDiv" *ngIf="isShowProjected">
+            <google-chart class="googleChart" [type]="'PieChart'" [data]="donutData.data" [options]="donutOptions" [dynamicResize]="true"></google-chart>
+        </div>        
     </div>
-
-    <div *ngIf="groupDeletion === 'fail'">
-        <div class="clr-row">
-            <div class="clr-col-8">
-                <clr-alert clrAlertType="danger" [clrAlertClosable]="true">
-                    <clr-alert-item>
-                        <div class="alert-item static">
-                            <span class="alert-text">
-                                    Group deletion failed<br/><br/>
-                                    Error: {{ deletionError }}
-                            </span>
-                        </div>
-                    </clr-alert-item>
-                </clr-alert>
-            </div>
-        </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-outline" (click)="isShowProjected = false">Close</button>
     </div>
+</clr-modal>
 
 

--- a/ui/src/app/modules/logical-group/components/logical-group.component.html
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.html
@@ -148,17 +148,29 @@
 </div>
 
 <div class="clr-row" *ngIf="isShowGroupDetails">
-    <div class="clr-col-lg-5 clr-col-md-8 clr-col-6">
+    <div class="clr-col-lg-12 clr-col-md-12 clr-col-12">
         <div class="card">
             <div class="card-header">
                 Resource Details for <b style="text-transform: uppercase;">{{ groupToFocus.name }}</b>
             </div>
             <div class="card-block">
                 <div class="card-text">
-                    Pods      : {{ groupToFocus.podsCount }}<br/>
-                    CPU       : {{ groupToFocus.cpu }}<br/>
-                    Memory    : {{ groupToFocus.memory }}<br/>
-                    Storage   : {{ groupToFocus.storage }}<br/>
+                <div class="row">
+                    <div class="clr-col-4">
+                        <b>Pods</b>      : {{ groupToFocus.podsCount }}<br/>
+                        <b>CPU</b>       : {{ groupToFocus.cpu }}<br/>
+                        <b>Memory</b>    : {{ groupToFocus.memory }}<br/>
+                        <b>Storage</b>   : {{ groupToFocus.storage }}<br/>
+                    </div>
+                    <div class="clr-col-2"></div>
+                    <div class="clr-col-4 progress-block">
+                            <label>Current Cost vs Projected</label>
+                            <div class="progress-static labeled">
+                                <div class="progress-meter" [attr.data-value]="costRatio" [attr.data-displayval]="costRatio + '%'"></div>
+                            </div>
+                            <span style="margin: 1%">{{ costRatio }}%</span>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/ui/src/app/modules/logical-group/components/logical-group.component.html
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.html
@@ -52,7 +52,6 @@
         <clr-dg-pagination #pagination [clrDgPageSize]="currentPageSize"></clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>
-<p class="p5"><i>* All costs are computed for Month To Date (MTD).</i></p>
 
 <form novalidate #f="ngForm" (ngSubmit)="createGroup();">
     <clr-modal [(clrModalOpen)]="isCreateGroup" [clrModalSize]="'lg'">
@@ -152,7 +151,7 @@
     <div class="clr-col-lg-5 clr-col-md-8 clr-col-6">
         <div class="card">
             <div class="card-header">
-                Group: ({{ groupToFocus.name }}) Resource Details
+                Resource Details for <b style="text-transform: uppercase;">{{ groupToFocus.name }}</b>
             </div>
             <div class="card-block">
                 <div class="card-text">
@@ -184,7 +183,7 @@
 </clr-modal>
 
 <clr-modal [(clrModalOpen)]="isShowProjected" [clrModalSize]="'lg'">
-    <h3 class="modal-title">MTD Costs</h3>
+    <h3 class="modal-title">Projected Costs</h3>
     <div class="modal-body">
         <div class="googleChartDiv" *ngIf="isShowProjected">
             <google-chart class="googleChart" [type]="'PieChart'" [data]="donutData.data" [options]="donutOptions" [dynamicResize]="true"></google-chart>

--- a/ui/src/app/modules/logical-group/components/logical-group.component.ts
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.ts
@@ -32,6 +32,7 @@ export class LogicalGroupComponent implements OnInit {
   public donutOptions = {};
   public donutData = {"data": []};
   public group: any;
+  public costRatio = 100;
 
   constructor(private router: Router, private logicalGroupService: LogicalGroupService) {
   }
@@ -100,6 +101,7 @@ export class LogicalGroupComponent implements OnInit {
     console.log("group: ", group);
     this.groupToFocus = group;
     this.isShowGroupDetails = true;
+    this.costRatio = Math.round(this.groupToFocus.mtdCost * 100 / this.groupToFocus.projectedCost);
   }
 
   public reset() {
@@ -124,7 +126,7 @@ export class LogicalGroupComponent implements OnInit {
     };
 
     this.donutOptions = {
-      title: 'Total MTD Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.mtdCost,
+      title: 'Total MTD Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.mtdCost.toFixed(2),
       pieHole: 0,
       pieSliceText: 'value-and-percentage',
       width: 750,
@@ -149,7 +151,7 @@ export class LogicalGroupComponent implements OnInit {
     };
 
     this.donutOptions = {
-      title: 'Total Projected Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.projectedCost,
+      title: 'Total Projected Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.projectedCost.toFixed(2),
       pieHole: 0,
       pieSliceText: 'value-and-percentage',
       width: 750,

--- a/ui/src/app/modules/logical-group/components/logical-group.component.ts
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.ts
@@ -127,7 +127,7 @@ export class LogicalGroupComponent implements OnInit {
 
     this.donutOptions = {
       title: 'Total MTD Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.mtdCost.toFixed(2),
-      pieHole: 0,
+      pieHole: 0.3,
       pieSliceText: 'value-and-percentage',
       width: 750,
       height: 400,
@@ -152,7 +152,7 @@ export class LogicalGroupComponent implements OnInit {
 
     this.donutOptions = {
       title: 'Total Projected Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.projectedCost.toFixed(2),
-      pieHole: 0,
+      pieHole: 0.3,
       pieSliceText: 'value-and-percentage',
       width: 750,
       height: 400,

--- a/ui/src/app/modules/logical-group/components/logical-group.component.ts
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.ts
@@ -19,16 +19,22 @@ export class LogicalGroupComponent implements OnInit {
   public GROUP_STATUS = STATUS_WAIT;
   public isCreateGroup = false;
   public isDeleteGroup = false;
+  public isShowGroupDetails = false;
   public toBeDeletedGroup = "Custom Group";
+  public groupToFocus: any;
   public groupCreation = 'wait';
   public groupDeletion = 'wait';
   public creationError = null;
   public deletionError = null;
 
+  public isShowMTD = false;
+  public isShowProjected = false;
+  public donutOptions = {};
+  public donutData = {"data": []};
   public group: any;
 
   constructor(private router: Router, private logicalGroupService: LogicalGroupService) {
-   }
+  }
 
 
   private getLogicalGroupData() {
@@ -86,17 +92,75 @@ export class LogicalGroupComponent implements OnInit {
   }
 
   public setToBeDeletedGroup(grpName) {
-    this.toBeDeletedGroup = grpName
+    this.toBeDeletedGroup = grpName;
+    this.isDeleteGroup = true;
+  }
+
+  public showGroupDetails(group) {
+    console.log("group: ", group);
+    this.groupToFocus = group;
+    this.isShowGroupDetails = true;
   }
 
   public reset() {
     this.isCreateGroup = false;
     this.getLogicalGroupData();
     this.isDeleteGroup = false;
+    this.isShowGroupDetails = false;
     this.toBeDeletedGroup = "Custom Group";
     this.group = null;
     this.groupCreation = 'wait';
     this.groupDeletion = 'wait';
+  }
+
+  public showMTD() {
+    this.isShowMTD = true;
+    this.donutData = {
+      "data": [
+        ['CPU', this.groupToFocus.mtdCPUCost],
+        ['Memory', this.groupToFocus.mtdMemoryCost],
+        ['Storage', this.groupToFocus.mtdStorageCost]
+      ]
+    };
+
+    this.donutOptions = {
+      title: 'Total MTD Cost: ' + this.groupToFocus.mtdCost,
+      pieHole: 0,
+      pieSliceText: 'value-and-percentage',
+      width: 900,
+      height: 500,
+      chartArea: {
+        left: "10%",
+        top: "10%",
+        height: "80%",
+        width: "80%"
+      }
+    };
+  }
+
+  public showProjected() {
+    this.isShowProjected = true;
+    this.donutData = {
+      "data": [
+        ['CPU', this.groupToFocus.projectedCPUCost],
+        ['Memory', this.groupToFocus.projectedMemoryCost],
+        ['Storage', this.groupToFocus.projectedStorageCost]
+      ]
+    };
+
+    this.donutOptions = {
+      title: 'Total Projected Cost: ' + this.groupToFocus.projectedCost,
+      pieHole: 0,
+      pieSliceText: 'value-and-percentage',
+      width: 900,
+      height: 500,
+      chartArea: {
+        left: "10%",
+        top: "10%",
+        height: "80%",
+        width: "80%"
+      }
+    };
   }
 
   ngOnInit() {

--- a/ui/src/app/modules/logical-group/components/logical-group.component.ts
+++ b/ui/src/app/modules/logical-group/components/logical-group.component.ts
@@ -124,11 +124,11 @@ export class LogicalGroupComponent implements OnInit {
     };
 
     this.donutOptions = {
-      title: 'Total MTD Cost: ' + this.groupToFocus.mtdCost,
+      title: 'Total MTD Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.mtdCost,
       pieHole: 0,
       pieSliceText: 'value-and-percentage',
-      width: 900,
-      height: 500,
+      width: 750,
+      height: 400,
       chartArea: {
         left: "10%",
         top: "10%",
@@ -149,11 +149,11 @@ export class LogicalGroupComponent implements OnInit {
     };
 
     this.donutOptions = {
-      title: 'Total Projected Cost: ' + this.groupToFocus.projectedCost,
+      title: 'Total Projected Cost for ' + this.groupToFocus.name + ': ' + this.groupToFocus.projectedCost,
       pieHole: 0,
       pieSliceText: 'value-and-percentage',
-      width: 900,
-      height: 500,
+      width: 750,
+      height: 400,
       chartArea: {
         left: "10%",
         top: "10%",


### PR DESCRIPTION
**What this PR does / why we need it**:
- Computes projected costs for each resource and total in the backend
- Shows projected costs for custom groups in UI
- Fix bug: Sometimes group events are missed by purser controller, with this commit the bug will be fixed.
- Also show PieChart for costs showing cost distribution among CPU, Memory and Storage.

**Which issue(s) this PR fixes**
Fixes #206 

**UI screenshots**
Hide/Show columns:
![Screenshot from 2019-03-26 11-53-44](https://user-images.githubusercontent.com/42461220/54976125-64342e80-4fbf-11e9-9b97-d0d430c7b0b2.png)

Projected Costs:
![Screenshot from 2019-03-26 11-54-05](https://user-images.githubusercontent.com/42461220/54976136-6eeec380-4fbf-11e9-8b73-9b73bb81b47c.png)

On click Group info:
![Screenshot from 2019-03-26 12-56-41](https://user-images.githubusercontent.com/42461220/54978592-c7758f00-4fc6-11e9-8783-0d35e665b938.png)


Pie Charts:
![Screenshot from 2019-03-26 13-56-02](https://user-images.githubusercontent.com/42461220/54981700-fabc1c00-4fce-11e9-9d4f-37adf73577a2.png)

![Screenshot from 2019-03-26 13-56-16](https://user-images.githubusercontent.com/42461220/54981704-fc85df80-4fce-11e9-9719-b493b1f5c2b9.png)







