### PR TITLE
Update makefile to separate docker output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vendor/
 /dist
 /tmp
 /out-tsc
+tmp/
 
 # dependencies
 node_modules/

--- a/.make/Makefile.deploy.controller
+++ b/.make/Makefile.deploy.controller
@@ -33,6 +33,7 @@ DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))
 container: $(DOCKER_OUT)/.container-$(DOTFILE_IMAGE) container-name
 $(DOCKER_OUT)/.container-$(DOTFILE_IMAGE): $(DOCKER_OUT)/bin/$(ARCH)/$(BIN) Dockerfile.in
 	@sed \
+	    -e 's|ARG_DOCK|$(DOCKER_OUT)|g' \
 	    -e 's|ARG_BIN|$(BIN)|g' \
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \

--- a/.make/Makefile.deploy.controller
+++ b/.make/Makefile.deploy.controller
@@ -1,21 +1,23 @@
 IMAGE := $(DOCKER_REPO)/$(BIN)-$(ARCH)
+OUTPUT_DIR := tmp
+DOCKER_OUT := $(OUTPUT_DIR)/docker
 
 .PHONY: build
-build: bin/$(ARCH)/$(BIN)
+build: $(DOCKER_OUT)/bin/$(ARCH)/$(BIN)
 
-bin/$(ARCH)/$(BIN): build-dirs
+$(DOCKER_OUT)/bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                            \
 	    -ti                                                                \
 	    -u $$(id -u):$$(id -g)                                             \
-	    -v $$(pwd)/.go:/go:$(DOCKER_MOUNT_MODE)                            \
+	    -v $$(pwd)/$(DOCKER_OUT)/.go:/go:$(DOCKER_MOUNT_MODE)                            \
         -v $$(pwd)/$(BUILD):/go/src/$(PRO)/$(BUILD):$(DOCKER_MOUNT_MODE)   \
 	    -v $$(pwd)/$(CMD):/go/src/$(PRO)/$(CMD):$(DOCKER_MOUNT_MODE)                     \
 	    -v $$(pwd)/$(PKG):/go/src/$(PRO)/$(PKG):$(DOCKER_MOUNT_MODE)                     \
 	    -v $$(pwd)/$(DEP):/go/src/$(PRO)/$(DEP):$(DOCKER_MOUNT_MODE)                     \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin:$(DOCKER_MOUNT_MODE)                \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin/linux_$(ARCH):$(DOCKER_MOUNT_MODE)  \
-	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static:$(DOCKER_MOUNT_MODE)  \
+	    -v $$(pwd)/$(DOCKER_OUT)/bin/$(ARCH):/go/bin:$(DOCKER_MOUNT_MODE)                \
+	    -v $$(pwd)/$(DOCKER_OUT)/bin/$(ARCH):/go/bin/linux_$(ARCH):$(DOCKER_MOUNT_MODE)  \
+	    -v $$(pwd)/$(DOCKER_OUT)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static:$(DOCKER_MOUNT_MODE)  \
 	    -w /go/src                                                 \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/sh -c "                                                       \
@@ -28,14 +30,14 @@ bin/$(ARCH)/$(BIN): build-dirs
 DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))
 
 .PHONY: container
-container: .container-$(DOTFILE_IMAGE) container-name
-.container-$(DOTFILE_IMAGE): bin/$(ARCH)/$(BIN) Dockerfile.in
+container: $(DOCKER_OUT)/.container-$(DOTFILE_IMAGE) container-name
+$(DOCKER_OUT)/.container-$(DOTFILE_IMAGE): $(DOCKER_OUT)/bin/$(ARCH)/$(BIN) Dockerfile.in
 	@sed \
 	    -e 's|ARG_BIN|$(BIN)|g' \
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
-	    Dockerfile.in > .dockerfile-$(ARCH)
-	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
+	    Dockerfile.in > $(DOCKER_OUT)/.dockerfile-$(ARCH)
+	@docker build -t $(IMAGE):$(VERSION) -f $(DOCKER_OUT)/.dockerfile-$(ARCH) .
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 .PHONY: container-name
@@ -43,8 +45,8 @@ container-name:
 	@echo "container: $(IMAGE):$(VERSION)"
 
 .PHONY: push
-push: .push-$(DOTFILE_IMAGE) push-name
-.push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
+push: $(DOCKER_OUT)/.push-$(DOTFILE_IMAGE) push-name
+$(DOCKER_OUT)/.push-$(DOTFILE_IMAGE): $(DOCKER_OUT)/.container-$(DOTFILE_IMAGE)
 ifeq ($(findstring gcr.io,$(DOCKER_REPO)),gcr.io)
 	@gcloud docker -- push $(IMAGE):$(VERSION)
 else
@@ -58,17 +60,18 @@ push-name:
 
 .PHONY: build-dirs
 build-dirs:
-	@mkdir -p bin/$(ARCH)
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH)
+	@mkdir -p $(DOCKER_OUT)
+	@mkdir -p $(DOCKER_OUT)/bin/$(ARCH)
+	@mkdir -p $(DOCKER_OUT)/.go/src/$(PKG) $(DOCKER_OUT)/.go/pkg $(DOCKER_OUT)/.go/bin $(DOCKER_OUT)/.go/std/$(ARCH)
 
 .PHONY: clean
 clean: container-clean bin-clean
 
 .PHONY: container-clean
 container-clean:
-	rm -rf .container-* .dockerfile-* .push-*
+	rm -rf $(DOCKER_OUT)/.container-* $(DOCKER_OUT)/.dockerfile-* $(DOCKER_OUT)/.push-*
 
 .PHONY: bin-clean
 bin-clean:
-	rm -rf .go bin
+	rm -rf $(DOCKER_OUT)/
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -3,4 +3,4 @@ FROM ARG_FROM
 LABEL maintainer = "VMware <hkatyal@vmware.com>"
 LABEL author = "Hemani Katyal <hkatyal@vmware.com>"
 
-ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+ADD ARG_DOCK/bin/ARG_ARCH/ARG_BIN /ARG_BIN

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CMD := cmd/controller
 
 # Where to push the docker image.
 REGISTRY?=docker.io
-DOCKER_REPO?=vmwareh
+DOCKER_REPO?=kreddyj
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH?= amd64


### PR DESCRIPTION
**What this PR does / why we need it**:
Outputs from `make build`, `make container` and `make push` will be written to `tmp/` folder.

**Which issue(s) this PR fixes**:
Fixes #221
