### PR TITLE
Add basic GCP pricing support

### DIFF
--- a/pkg/controller/dgraph/models/constants.go
+++ b/pkg/controller/dgraph/models/constants.go
@@ -12,6 +12,7 @@ const (
 
 	// Cloud provider constants
 	AWS = "aws"
+	GCP = "gcp"
 
 	// Time constants
 	HoursInMonth = 720

--- a/pkg/controller/dgraph/models/rateCard.go
+++ b/pkg/controller/dgraph/models/rateCard.go
@@ -187,6 +187,7 @@ func getPerUnitResourcePriceForNode(nodeName string) (float64, float64) {
 }
 
 func getPricePerUnitResourceFromNodePrice(node Node) (float64, float64) {
+	// TODO: Get correct node price reliably
 	nodePriceXID := node.InstanceType + "-" + node.OS
 	nodePrice, err := retrieveNodePrice(nodePriceXID)
 	if err == nil {

--- a/pkg/pricing/cloud.go
+++ b/pkg/pricing/cloud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/vmware/purser/pkg/controller/dgraph/models"
 	"github.com/vmware/purser/pkg/pricing/aws"
+	"github.com/vmware/purser/pkg/pricing/gcp"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -34,17 +35,26 @@ type Cloud struct {
 // GetClusterProviderAndRegion returns cluster provider(ex: aws) and region(ex: us-east-1)
 func GetClusterProviderAndRegion() (string, string) {
 	// TODO: https://github.com/vmware/purser/issues/143
-	cloudProvider := models.AWS
-	region := "us-east-1"
+	cloudProvider := models.GCP
+	region := "us-central1"
 	logrus.Infof("CloudProvider: %s, Region: %s", cloudProvider, region)
 	return cloudProvider, region
 }
 
 // PopulateRateCard given a cloud (cloudProvider and region) it populates corresponding rate card in dgraph
 func (c *Cloud) PopulateRateCard() {
+	var rateCard *models.RateCard
+
 	switch c.CloudProvider {
 	case models.AWS:
-		rateCard := aws.GetRateCardForAWS(c.Region)
+		rateCard = aws.GetRateCardForAWS(c.Region)
+	case models.GCP:
+		rateCard = gcp.GetRateCardForGCP(c.Region)
+	}
+
+	if rateCard != nil {
 		models.StoreRateCard(rateCard)
+	} else {
+		logrus.Printf("Could not get rate card")
 	}
 }

--- a/pkg/pricing/gcp/convert.go
+++ b/pkg/pricing/gcp/convert.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2019 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gcp
+
+import (
+	"errors"
+	"math"
+	"strconv"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/dgraph"
+	"github.com/vmware/purser/pkg/controller/dgraph/models"
+)
+
+// put somewhere else
+func contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+// GetRateCardForGCP gets the rate card for a given region
+func GetRateCardForGCP(region string) *models.RateCard {
+	computePricing, err1 := GetGCPPricingCompute(region)
+	storagePricing, err2 := GetGCPPricingStorage(region)
+	if err1 == nil && err2 == nil {
+		return getPurserRateCard(region, computePricing, storagePricing)
+	}
+	return nil
+}
+
+func getPurserRateCard(region string, computePricing *Pricing, storagePricing *Pricing) *models.RateCard {
+	nodePrices := getNodePricesFromGCPPricing(computePricing)
+	storagePrices := getStoragePricesFromGCPPricing(storagePricing)
+	return &models.RateCard{
+		ID:            dgraph.ID{Xid: models.RateCardXID},
+		IsRateCard:    true,
+		CloudProvider: models.GCP,
+		Region:        region,
+		NodePrices:    nodePrices,
+		StoragePrices: storagePrices,
+	}
+}
+
+func getStoragePricesFromGCPPricing(pricing *Pricing) []*models.StoragePrice {
+	var storagePrices []*models.StoragePrice
+	filterStoragePricing(pricing)
+	for _, sku := range pricing.Skus {
+		price, _ := getPriceFromSku(&sku)
+		switch sku.PricingInfo[0].PricingExpression.UsageUnit {
+		case "GiBy.mo":
+			price = price / models.HoursInMonth
+		case "GiBy.d":
+			price = price / 24
+		default:
+			price = 0 // change?
+		}
+		productXID := sku.Category.ResourceGroup
+		storagePrice := &models.StoragePrice{
+			ID:             dgraph.ID{Xid: productXID},
+			IsStoragePrice: true,
+			VolumeType:     "ANY",
+			UsageType:      sku.Category.ResourceGroup,
+			Price:          price,
+		}
+		uid := models.StoreStoragePrice(storagePrice, productXID)
+		if uid != "" {
+			storagePrice.ID = dgraph.ID{UID: uid, Xid: productXID}
+			storagePrices = append(storagePrices, storagePrice)
+		}
+	}
+	return storagePrices
+}
+
+func getNodePricesFromGCPPricing(pricing *Pricing) []*models.NodePrice {
+	var nodePrices []*models.NodePrice
+	var computeByRG map[string][]Skus
+	computeByRG = make(map[string][]Skus)
+	var cpuPrice, memoryPrice float64
+	filterComputePricing(pricing)
+	groupNodesByResourceGroupCompute(pricing.Skus, computeByRG)
+	for _, skus := range computeByRG {
+		// there should ideally be only 1 or 2 skus for a single resource group
+		if len(skus) == 1 {
+			// only compute
+			cpuPrice, _ = getPriceFromSku(&skus[0])
+			memoryPrice = 0
+		} else if len(skus) == 2 {
+			if isCPUSku(&skus[0]) {
+				cpuPrice, _ = getPriceFromSku(&skus[0])
+				memoryPrice, _ = getPriceFromSku(&skus[1])
+			} else {
+				cpuPrice, _ = getPriceFromSku(&skus[1])
+				memoryPrice, _ = getPriceFromSku(&skus[0])
+			}
+		} else {
+			logrus.Errorf("Unexpected no. of skus in resource group. Skipping...")
+			continue
+		}
+		if cpuPrice != 0 {
+			productXID := skus[0].Category.ResourceGroup
+			nodePrice := &models.NodePrice{
+				ID:              dgraph.ID{Xid: productXID},
+				IsNodePrice:     true,
+				InstanceType:    skus[0].Category.ResourceGroup,
+				InstanceFamily:  "ANY",
+				OperatingSystem: "ANY",
+				Price:           0,
+				PricePerCPU:     cpuPrice,
+				PricePerMemory:  memoryPrice,
+			}
+			uid := models.StoreNodePrice(nodePrice, productXID)
+			if uid != "" {
+				nodePrice.ID = dgraph.ID{UID: uid, Xid: productXID}
+				nodePrices = append(nodePrices, nodePrice)
+			}
+		}
+	}
+	return nodePrices
+}
+
+func groupNodesByResourceGroupCompute(skus []Skus, group map[string][]Skus) {
+	for _, sku := range skus {
+		group[sku.Category.ResourceGroup] = append(group[sku.Category.ResourceGroup], sku)
+	}
+}
+
+// assumes all rates are per hour
+func isCPUSku(sku *Skus) bool {
+	return sku.PricingInfo[0].PricingExpression.UsageUnit == "h"
+}
+
+// assumes all rates are per GB per hour
+func isMemorySku(sku *Skus) bool {
+	return sku.PricingInfo[0].PricingExpression.UsageUnit == "GiBy.h"
+}
+
+func filterComputePricing(pricing *Pricing) {
+	exceptResourceGroups := []string{"RAM", "GPU", "CPU", "PdSnapshotEgress", "SecurityPolicy"} // put somewhere else
+	var newSkus []Skus
+
+	for _, el := range pricing.Skus {
+		if el.Category.ResourceFamily == "Compute" &&
+			!contains(exceptResourceGroups, el.Category.ResourceGroup) &&
+			el.Category.UsageType != "Preemptible" {
+			newSkus = append(newSkus, el)
+		}
+	}
+	pricing.Skus = newSkus
+}
+
+func filterStoragePricing(pricing *Pricing) {
+	allowedResourceGroups := []string{"ColdlineStorage", "RegionalStorage", "DRAStorage", "NearlineStorage"} // put somewhere else
+	var newSkus []Skus
+
+	for _, el := range pricing.Skus {
+		if el.Category.ResourceFamily == "Storage" &&
+			contains(allowedResourceGroups, el.Category.ResourceGroup) &&
+			el.Category.UsageType != "Preemptible" {
+			newSkus = append(newSkus, el)
+		}
+	}
+	pricing.Skus = newSkus
+}
+
+// PricingInfo and TieredRates are usually length 1
+func getPriceFromSku(sku *Skus) (float64, error) {
+	var price float64
+	el := *sku
+	if len(el.PricingInfo) != 1 {
+		return 0, errors.New("Unexpected PricingInfo")
+	}
+	for _, tr := range el.PricingInfo[0].PricingExpression.TieredRates {
+		units, err := strconv.ParseFloat(tr.UnitPrice.Units, 64)
+		if err != nil {
+			return 0, errors.New("Invalid units")
+		}
+		price = units + tr.UnitPrice.Nanos*math.Pow10(-9)
+		if price != 0 {
+			break
+		}
+	}
+	if price == 0 {
+		return 0, errors.New("Unable to get price")
+	}
+	return price, nil
+}

--- a/pkg/pricing/gcp/gcp.go
+++ b/pkg/pricing/gcp/gcp.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2019 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gcp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/vmware/purser/pkg/controller/utils"
+)
+
+const (
+	httpTimeout = 100 * time.Second
+	apiKey      = "your-api-key-here"
+	computeURL  = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus"
+	storageURL  = "https://cloudbilling.googleapis.com/v1/services/95FF-2EF5-5EA1/skus"
+)
+
+/*
+ * The following structs are modelled according to the GCP Pricing API response
+ * https://cloud.google.com/billing/v1/how-tos/catalog-api
+ */
+
+// Pricing structure
+type Pricing struct {
+	Skus          []Skus `json:"skus"`
+	NextPageToken string `json:"nextPageToken"`
+}
+
+// Category structure
+type Category struct {
+	ServiceDisplayName string `json:"serviceDisplayName"`
+	ResourceFamily     string `json:"resourceFamily"`
+	ResourceGroup      string `json:"resourceGroup"`
+	UsageType          string `json:"usageType"`
+}
+
+// UnitPrice structure
+type UnitPrice struct {
+	CurrencyCode string  `json:"currencyCode"`
+	Units        string  `json:"units"`
+	Nanos        float64 `json:"nanos"`
+}
+
+// TieredRates structure
+type TieredRates struct {
+	StartUsageAmount int       `json:"startUsageAmount"`
+	UnitPrice        UnitPrice `json:"unitPrice"`
+}
+
+// PricingExpression structure
+type PricingExpression struct {
+	UsageUnit            string        `json:"usageUnit"`
+	UsageUnitDescription string        `json:"usageUnitDescription"`
+	DisplayQuantity      int           `json:"displayQuantity"`
+	TieredRates          []TieredRates `json:"tieredRates"`
+}
+
+// AggregationInfo structure
+type AggregationInfo struct {
+	AggregationLevel    string `json:"aggregationLevel"`
+	AggregationInterval string `json:"aggregationInterval"`
+	AggregationCount    int    `json:"aggregationCount"`
+}
+
+// PricingInfo structure
+type PricingInfo struct {
+	EffectiveTime          string            `json:"effectiveTime"`
+	Summary                string            `json:"summary"`
+	PricingExpression      PricingExpression `json:"pricingExpression"`
+	AggregationInfo        AggregationInfo   `json:"aggregationInfo"`
+	CurrencyConversionRate int               `json:"currencyConversionRate"`
+}
+
+// Skus structure
+type Skus struct {
+	Name                string        `json:"name"`
+	SkuID               string        `json:"skuId"`
+	Description         string        `json:"description"`
+	Category            Category      `json:"category"`
+	ServiceRegions      []string      `json:"serviceRegions"`
+	PricingInfo         []PricingInfo `json:"pricingInfo"`
+	ServiceProviderName string        `json:"serviceProviderName"`
+}
+
+func getGCPPRicingHelper(url string, region string) (*Pricing, error) {
+	var myClient = &http.Client{Timeout: httpTimeout}
+	pricing := Pricing{}
+	for {
+		temp := Pricing{}
+		err := utils.GetJSONResponse(myClient, url, &temp)
+		if err != nil {
+			logrus.Errorf("Unable to get gcp pricing. Reason: %v", err)
+			return nil, err
+		}
+
+		for _, sku := range temp.Skus {
+			if contains(sku.ServiceRegions, region) {
+				// handle "global" region?
+				pricing.Skus = append(pricing.Skus, sku)
+			}
+		}
+
+		if temp.NextPageToken != "" {
+			url = fmt.Sprintf("%s&pageToken=%s", url, temp.NextPageToken)
+		} else {
+			break
+		}
+	}
+
+	if len(pricing.Skus) == 0 {
+		return nil, errors.New("Unable to fetch data from api")
+	}
+
+	return &pricing, nil
+}
+
+// GetGCPPricingCompute calls the gcp pricing api and filters on region
+func GetGCPPricingCompute(region string) (*Pricing, error) {
+	pricing, err := getGCPPRicingHelper(fmt.Sprintf("%s?key=%s", computeURL, apiKey), region)
+	return pricing, err
+}
+
+// GetGCPPricingStorage calls the gcp pricing api and filters on region
+func GetGCPPricingStorage(region string) (*Pricing, error) {
+	pricing, err := getGCPPRicingHelper(fmt.Sprintf("%s?key=%s", storageURL, apiKey), region)
+	return pricing, err
+}


### PR DESCRIPTION
Add support to fetch GCP rate cards using the GCP pricing API (https://cloud.google.com/billing/v1/how-tos/catalog-api)