### PR TITLE
gh-270: fixed casing for 'spec' in subscribers query

### DIFF
--- a/pkg/controller/dgraph/models/query/queries.go
+++ b/pkg/controller/dgraph/models/query/queries.go
@@ -359,7 +359,7 @@ func getQueryForSubscribersRetrieval() string {
 	return `query {
 		subscribers(func: has(isSubscriber)) @filter(NOT(has(endTime))) {
 			name
-			Spec {
+			spec {
 				headers
 				url
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
The Subscribers feature does not work otherwise.

**Which issue(s) this PR fixes**
Resolves gh-270

**Special notes for your reviewer**:
None that I can think of
